### PR TITLE
Changing "Assign an adviser" references to "Allocate an adviser"

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetAdviserDetails.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetAdviserDetails.cs
@@ -8,7 +8,7 @@ public class SetAdviserDetails
 {
     public record SetAdviserDetailsCommand(
         SupportProjectId SupportProjectId,
-        DateTime? DateAdviserAssigned,
+        DateTime? DateAdviserAllocated,
         string? AdviserEmailAddress
     ) : IRequest<bool>;
 
@@ -25,7 +25,7 @@ public class SetAdviserDetails
                 return false;
             }
 
-            supportProject.SetAdviserDetails(request.AdviserEmailAddress, request.DateAdviserAssigned);
+            supportProject.SetAdviserDetails(request.AdviserEmailAddress, request.DateAdviserAllocated);
 
             await supportProjectRepository.UpdateAsync(supportProject, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
@@ -21,7 +21,7 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Models
         DateTime? SchoolResponseDate = null,
         bool? HasAcceeptedTargetedSupport = null,
         bool? HasSavedSchoolResponseinSharePoint = null,
-        DateTime? DateAdviserAssigned = null,
+        DateTime? DateAdviserAllocated = null,
         string? AdviserEmailAddress = null,
         DateTime? IntroductoryEmailSentDate = null,
         bool? HasShareEmailTemplateWithAdvisor = null,

--- a/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
+++ b/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
@@ -72,7 +72,7 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
 
     public bool? HasSavedSchoolResponseinSharePoint { get; private set; }
 
-    public DateTime? DateAdviserAssigned { get; private set; }
+    public DateTime? DateAdviserAllocated { get; private set; }
     public string? AdviserEmailAddress { get; private set; }
 
     public DateTime? IntroductoryEmailSentDate { get; private set; }
@@ -215,9 +215,9 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
         HasSavedSchoolResponseinSharePoint = hasSavedSchoolResponseinSharePoint;
     }
 
-    public void SetAdviserDetails(string? adviserEmailAddress, DateTime? dateAdviserAssigned)
+    public void SetAdviserDetails(string? adviserEmailAddress, DateTime? dateAdviserAllocated)
     {
-        DateAdviserAssigned = dateAdviserAssigned;
+        DateAdviserAllocated = dateAdviserAllocated;
         AdviserEmailAddress = adviserEmailAddress;
     }
 

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250304162749_RenamedDateAdviserAssigned.Designer.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250304162749_RenamedDateAdviserAssigned.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageSchoolImprovement.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
 {
     [DbContext(typeof(RegionalImprovementForStandardsAndExcellenceContext))]
-    partial class RegionalImprovementForStandardsAndExcellenceContextModelSnapshot : ModelSnapshot
+    [Migration("20250304162749_RenamedDateAdviserAssigned")]
+    partial class RenamedDateAdviserAssigned
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250304162749_RenamedDateAdviserAssigned.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250304162749_RenamedDateAdviserAssigned.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenamedDateAdviserAssigned : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DateAdviserAssigned",
+                schema: "RISE",
+                table: "SupportProject",
+                newName: "DateAdviserAllocated")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DateAdviserAllocated",
+                schema: "RISE",
+                table: "SupportProject",
+                newName: "DateAdviserAssigned")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+    }
+}

--- a/src/Dfe.ManageSchoolImprovement/Models/Links.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/Links.cs
@@ -46,7 +46,7 @@ public static class Links
         public static readonly LinkItem ContactTheSchool = AddLinkItem(backText: "Back", page: "/TaskList/ContactTheSchool/ContactTheSchool");
         public static readonly LinkItem RecordTheSchoolResponse = AddLinkItem(backText: "Back", page: "/TaskList/RecordTheSchoolResponse/Index");
         public static readonly LinkItem CheckPotentialAdviserConflictsOfInterest = AddLinkItem(backText: "Back", page: "/TaskList/AdviserConflictOfInterest/AdviserConflictOfInterest");
-        public static readonly LinkItem AssignAnAdviser = AddLinkItem(backText: "Back", page: "/TaskList/AssignAdviser/AssignAdviser");
+        public static readonly LinkItem AllocateAdviser = AddLinkItem(backText: "Back", page: "/TaskList/AllocateAdviser/AllocateAdviser");
         public static readonly LinkItem SendIntroductoryEmail = AddLinkItem(backText: "Back", page: "/TaskList/SendIntroductoryEmail/Index");
         public static readonly LinkItem ArrangeAdviserVisitToSchool = AddLinkItem(backText: "Back", page: "/TaskList/ArrangeAdviserVisitToSchool/ArrangeAdviserVisitToSchool");
         public static readonly LinkItem CompleteAndSaveAssessmentTemplate = AddLinkItem(backText: "Back", page: "/TaskList/CompleteAndSaveAssessmentTemplate/Index");

--- a/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
@@ -54,7 +54,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
 
         public bool? HasSavedSchoolResponseinSharePoint { get; set; }
 
-        public DateTime? DateAdviserAssigned { get; private set; }
+        public DateTime? DateAdviserAllocated { get; private set; }
         public string? AdviserEmailAddress { get; private set; }
 
         public DateTime? IntroductoryEmailSentDate { get; set; }
@@ -156,7 +156,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
                 RemindAdvisorToCopyRiseTeamWhenSentEmail = supportProjectDto.RemindAdvisorToCopyRiseTeamWhenSentEmail,
                 IntroductoryEmailSentDate = supportProjectDto.IntroductoryEmailSentDate,
                 AdviserEmailAddress = supportProjectDto.AdviserEmailAddress,
-                DateAdviserAssigned = supportProjectDto.DateAdviserAssigned,
+                DateAdviserAllocated = supportProjectDto.DateAdviserAllocated,
                 SavedAssessmentTemplateInSharePointDate = supportProjectDto.SavedAssessmentTemplateInSharePointDate,
                 HasTalkToAdviserAboutFindings = supportProjectDto.HasTalkToAdviserAboutFindings,
                 HasCompleteAssessmentTemplate = supportProjectDto.HasCompleteAssessmentTemplate,

--- a/src/Dfe.ManageSchoolImprovement/Pages/Shared/_ProjectHeader.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Shared/_ProjectHeader.cshtml
@@ -65,7 +65,7 @@
             <a data-id="assigned-user">@Model.AdviserEmailAddress</a>
          }
 
-         <a class="govuk-link govuk-!-padding-left-50" asp-page="@Links.TaskList.AssignAnAdviser.Page" asp-route-id="@Model.Id">Change</a>    
+            <a class="govuk-link govuk-!-padding-left-50" asp-page="@Links.TaskList.AllocateAdviser.Page" asp-route-id="@Model.Id">Change</a>
         </p>
 
         @if (User.IsInRole(Role.Support))

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml
@@ -1,7 +1,7 @@
-@page "/task-list/assign-adviser/{id:int}"
+@page "/task-list/allocate-adviser/{id:int}"
 @using Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
 @using Dfe.Academisation.ExtensionMethods
-@model AssignAdviser
+@model AllocateAdviser
 
 @{
     ViewData["Title"] = "Allocate an adviser";
@@ -48,7 +48,7 @@
                     <input class="govuk-input govuk-!-width-two-thirds @(Model.AdviserEmailAddressError ? "govuk-input--error" : "")" id="adviser-email-address" name="adviser-email-address" type="text" value="@Model.AdviserEmailAddress">
                 </div>
             </div>
-            <govuk-date-input heading-label="false" label="Enter date the adviser was allocated" id="date-adviser-assigned" name="date-adviser-assigned" asp-for="@Model.DateAdviserAssigned" hint="For example, 1 7 2024." />
+            <govuk-date-input heading-label="false" label="Enter date the adviser was allocated" id="date-adviser-allocated" name="date-adviser-allocated" asp-for="@Model.DateAdviserAllocated" hint="For example, 1 7 2024." />
             <input type="hidden" asp-for="@Model.Referrer"/>
             <button class="govuk-button" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">
                 Save and return

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml.cs
@@ -7,18 +7,18 @@ using Microsoft.AspNetCore.Mvc;
 using System.ComponentModel.DataAnnotations;
 using static Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.UpdateSupportProject.SetAdviserDetails;
 
-namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.AssignAdviser;
+namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.AllocateAdviser;
 
-public class AssignAdviser(ISupportProjectQueryService supportProjectQueryService, ErrorService errorService, IMediator mediator) : BaseSupportProjectPageModel(supportProjectQueryService, errorService), IDateValidationMessageProvider
+public class AllocateAdviser(ISupportProjectQueryService supportProjectQueryService, ErrorService errorService, IMediator mediator) : BaseSupportProjectPageModel(supportProjectQueryService, errorService), IDateValidationMessageProvider
 {
     [BindProperty(Name = "adviser-email-address")]
     [RiseAdviserEmail]
     public string? AdviserEmailAddress { get; set; }
 
-    [BindProperty(Name = "date-adviser-assigned", BinderType = typeof(DateInputModelBinder))]
+    [BindProperty(Name = "date-adviser-allocated", BinderType = typeof(DateInputModelBinder))]
     [DateValidation(DateRangeValidationService.DateRange.PastOrToday)]
-    [Display(Name = "date adviser was assigned")]
-    public DateTime? DateAdviserAssigned { get; set; }
+    [Display(Name = "date adviser was allocated")]
+    public DateTime? DateAdviserAllocated { get; set; }
     
     public string? Referrer { get; set; }
 
@@ -49,7 +49,7 @@ public class AssignAdviser(ISupportProjectQueryService supportProjectQueryServic
 
         AdviserEmailAddress = SupportProject.AdviserEmailAddress;
 
-        DateAdviserAssigned = SupportProject.DateAdviserAssigned;
+        DateAdviserAllocated = SupportProject.DateAdviserAllocated;
 
         Referrer = TempData["AssignmentReferrer"] == null ? @Links.TaskList.Index.Page : TempData["AssignmentReferrer"].ToString();
         
@@ -66,7 +66,7 @@ public class AssignAdviser(ISupportProjectQueryService supportProjectQueryServic
             return await base.GetSupportProject(id, cancellationToken);
         }
 
-        var request = new SetAdviserDetailsCommand(new SupportProjectId(id), DateAdviserAssigned, AdviserEmailAddress);
+        var request = new SetAdviserDetailsCommand(new SupportProjectId(id), DateAdviserAllocated, AdviserEmailAddress);
 
         var result = await mediator.Send(request, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/RiseAdviserEmailAttribute.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/RiseAdviserEmailAttribute.cs
@@ -1,4 +1,4 @@
-namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.AssignAdviser
+namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.AllocateAdviser
 {
     using System.ComponentModel.DataAnnotations;
     using System.Text.RegularExpressions;

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AssignAdviser/AssignAdviser.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AssignAdviser/AssignAdviser.cshtml
@@ -4,7 +4,7 @@
 @model AssignAdviser
 
 @{
-    ViewData["Title"] = "Assign an adviser";
+    ViewData["Title"] = "Allocate an adviser";
 }
 
 @section BeforeMain
@@ -25,10 +25,10 @@
         <form method="post" novalidate>
             <div class="govuk-form-group">
                 <h1 class="govuk-heading-l">
-                    Assign an adviser
+                    Allocate an adviser
                 </h1>
                 <p class="govuk-body">
-                    Enter the email address of the adviser and the date they were assigned to this school.
+                    Enter the email address of the adviser and the date they were allocated to this school.
                 </p>
                 <div class="govuk-form-group @(Model.AdviserEmailAddressError ? "govuk-form-group--error" : "")">
                     <h2 class="govuk-label-wrapper">
@@ -48,7 +48,7 @@
                     <input class="govuk-input govuk-!-width-two-thirds @(Model.AdviserEmailAddressError ? "govuk-input--error" : "")" id="adviser-email-address" name="adviser-email-address" type="text" value="@Model.AdviserEmailAddress">
                 </div>
             </div>
-            <govuk-date-input heading-label="false" label="Enter date the adviser was assigned" id="date-adviser-assigned" name="date-adviser-assigned" asp-for="@Model.DateAdviserAssigned" hint="For example, 1 7 2024." />
+            <govuk-date-input heading-label="false" label="Enter date the adviser was allocated" id="date-adviser-assigned" name="date-adviser-assigned" asp-for="@Model.DateAdviserAssigned" hint="For example, 1 7 2024." />
             <input type="hidden" asp-for="@Model.Referrer"/>
             <button class="govuk-button" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">
                 Save and return

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -52,7 +52,7 @@
                 <li class="app-task-list__item">
                     <span class="app-task-list__task-name" data-cy="task-name">
                         <a class="govuk-link" asp-page="@Links.TaskList.AssignAnAdviser.Page" asp-route-id="@Model.SupportProject.Id" aria-describedby="assign-adviser-status" data-cy="AssignAdviser">
-                            Assign an adviser
+                            Allocate an adviser
                         </a>
                     </span>
                     <partial name="Shared/_TaskListStatus" model="@Model.AssignAdviserTaskListStatus" />

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -51,11 +51,11 @@
                 </li>
                 <li class="app-task-list__item">
                     <span class="app-task-list__task-name" data-cy="task-name">
-                        <a class="govuk-link" asp-page="@Links.TaskList.AssignAnAdviser.Page" asp-route-id="@Model.SupportProject.Id" aria-describedby="assign-adviser-status" data-cy="AssignAdviser">
+                        <a class="govuk-link" asp-page="@Links.TaskList.AllocateAdviser.Page" asp-route-id="@Model.SupportProject.Id" aria-describedby="allocate-adviser-status" data-cy="AllocateAdviser">
                             Allocate an adviser
                         </a>
                     </span>
-                    <partial name="Shared/_TaskListStatus" model="@Model.AssignAdviserTaskListStatus" />
+                    <partial name="Shared/_TaskListStatus" model="@Model.AllocateAdviserTaskListStatus" />
                 </li>
             </ul>
         </div>

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
@@ -14,7 +14,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
     public TaskListStatus RecordTheSchoolResponseTaskListStatus { get; set; }
     public TaskListStatus CheckThePotentialAdviserConflictsOfInterestTaskListStatus { get; set; }
     public TaskListStatus SendIntroductoryEmailTaskListStatus { get; set; }
-    public TaskListStatus AssignAdviserTaskListStatus { get; set; }
+    public TaskListStatus AllocateAdviserTaskListStatus { get; set; }
 
     public TaskListStatus AdviserVisitToSchoolTaskListStatus { get; set; }
     public TaskListStatus CompleteAndSaveAssessmentTemplateTaskListStatus { get; set; }
@@ -57,7 +57,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
         ContactTheSchoolTaskListStatus = TaskStatusViewModel.ContactedTheSchoolTaskStatus(SupportProject);
         RecordTheSchoolResponseTaskListStatus = TaskStatusViewModel.RecordTheSchoolResponseTaskStatus(SupportProject);
         CheckThePotentialAdviserConflictsOfInterestTaskListStatus = TaskStatusViewModel.CheckThePotentialAdviserConflictsOfInterestTaskListStatus(SupportProject);
-        AssignAdviserTaskListStatus = TaskStatusViewModel.CheckAssignAdviserTaskListStatus(SupportProject);
+        AllocateAdviserTaskListStatus = TaskStatusViewModel.CheckAllocateAdviserTaskListStatus(SupportProject);
         SendIntroductoryEmailTaskListStatus = TaskStatusViewModel.SendIntroductoryEmailTaskListStatus(SupportProject);
         AdviserVisitToSchoolTaskListStatus = TaskStatusViewModel.AdviserVisitToSchoolTaskListStatus(SupportProject);
         CompleteAndSaveAssessmentTemplateTaskListStatus = TaskStatusViewModel.CompleteAndSaveAssessmentTemplateTaskListStatus(SupportProject);

--- a/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
@@ -67,16 +67,16 @@ public static class TaskStatusViewModel
         return TaskListStatus.InProgress;
     }
 
-    public static TaskListStatus CheckAssignAdviserTaskListStatus(SupportProjectViewModel supportProject)
+    public static TaskListStatus CheckAllocateAdviserTaskListStatus(SupportProjectViewModel supportProject)
     {
         if (supportProject.AdviserEmailAddress != null
-            && supportProject.DateAdviserAssigned.HasValue)
+            && supportProject.DateAdviserAllocated.HasValue)
         {
             return TaskListStatus.Complete;
         }
 
         if (supportProject.AdviserEmailAddress == null
-            && !supportProject.DateAdviserAssigned.HasValue)
+            && !supportProject.DateAdviserAllocated.HasValue)
         {
             return TaskListStatus.NotStarted;
         }

--- a/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
@@ -154,16 +154,16 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             var supportProject = CreateSupportProject();
 
             string? adviserEmailAddress = "test";
-            DateTime? dateAssigned = DateTime.UtcNow;
+            DateTime? dateAdviserAllocated = DateTime.UtcNow;
 
             // Act
             supportProject.SetAdviserDetails(
                 adviserEmailAddress,
-                dateAssigned);
+                dateAdviserAllocated);
 
             // Assert
             supportProject.AdviserEmailAddress.Should().Be(adviserEmailAddress);
-            supportProject.DateAdviserAssigned.Should().Be(dateAssigned);
+            supportProject.DateAdviserAllocated.Should().Be(dateAdviserAllocated);
             mockRepository.VerifyAll();
         }
 

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/LinksTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/LinksTests.cs
@@ -115,7 +115,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Models
         [InlineData("/TaskList/ContactTheSchool/ContactTheSchool")]
         [InlineData("/TaskList/RecordTheSchoolResponse/Index")]
         [InlineData("/TaskList/AdviserConflictOfInterest/AdviserConflictOfInterest")]
-        [InlineData("/TaskList/AssignAdviser/AssignAdviser")]
+        [InlineData("/TaskList/AllocateAdviser/AllocateAdviser")]
         [InlineData("/TaskList/SendIntroductoryEmail/Index")]
         [InlineData("/TaskList/ArrangeAdviserVisitToSchool/ArrangeAdviserVisitToSchool")]
         [InlineData("/TaskList/CompleteAndSaveAssessmentTemplate/Index")]

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/SupportProjectViewModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/SupportProjectViewModelTests.cs
@@ -30,7 +30,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Models
                 SchoolResponseDate: DateTime.Now,
                 HasAcceeptedTargetedSupport: true,
                 HasSavedSchoolResponseinSharePoint: true,
-                DateAdviserAssigned: DateTime.Now,
+                DateAdviserAllocated: DateTime.Now,
                 AdviserEmailAddress: "adviser@example.com",
                 IntroductoryEmailSentDate: DateTime.Now,
                 HasShareEmailTemplateWithAdvisor: true,
@@ -106,7 +106,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Models
             Assert.Equal(supportProjectDto.RemindAdvisorToCopyRiseTeamWhenSentEmail, viewModel.RemindAdvisorToCopyRiseTeamWhenSentEmail);
             Assert.Equal(supportProjectDto.IntroductoryEmailSentDate, viewModel.IntroductoryEmailSentDate);
             Assert.Equal(supportProjectDto.AdviserEmailAddress, viewModel.AdviserEmailAddress);
-            Assert.Equal(supportProjectDto.DateAdviserAssigned, viewModel.DateAdviserAssigned);
+            Assert.Equal(supportProjectDto.DateAdviserAllocated, viewModel.DateAdviserAllocated);
             Assert.Equal(supportProjectDto.SavedAssessmentTemplateInSharePointDate, viewModel.SavedAssessmentTemplateInSharePointDate);
             Assert.Equal(supportProjectDto.HasTalkToAdviserAboutFindings, viewModel.HasTalkToAdviserAboutFindings);
             Assert.Equal(supportProjectDto.HasCompleteAssessmentTemplate, viewModel.HasCompleteAssessmentTemplate);

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Pages/TaskList/TaskListIndexModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Pages/TaskList/TaskListIndexModelTests.cs
@@ -69,7 +69,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Pages.TaskList
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.ContactTheSchoolTaskListStatus);
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.RecordTheSchoolResponseTaskListStatus);
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.CheckThePotentialAdviserConflictsOfInterestTaskListStatus);
-            Assert.Equal(TaskListStatus.NotStarted, _indexModel.AssignAdviserTaskListStatus);
+            Assert.Equal(TaskListStatus.NotStarted, _indexModel.AllocateAdviserTaskListStatus);
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.SendIntroductoryEmailTaskListStatus);
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.AdviserVisitToSchoolTaskListStatus);
             Assert.Equal(TaskListStatus.NotStarted, _indexModel.CompleteAndSaveAssessmentTemplateTaskListStatus);

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
@@ -141,21 +141,21 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.ViewModels
             Assert.Equal(expectedTaskListStatus, taskListStatus);
         }
 
-        public static readonly TheoryData<string?, DateTime?, TaskListStatus> CheckAssignAdviserTaskListStatusCases = new()
+        public static readonly TheoryData<string?, DateTime?, TaskListStatus> CheckAllocateAdviserTaskListStatusCases = new()
         {
             {null, null, TaskListStatus.NotStarted },
             {"test@email.com", null, TaskListStatus.InProgress},
             {"test@email.com", DateTime.Now, TaskListStatus.Complete }
         };
 
-        [Theory, MemberData(nameof(CheckAssignAdviserTaskListStatusCases))]
-        public void CheckAssignAdviserTaskListStatusShouldReturnCorrectStatus(string? adviserEmailAddress, DateTime? dateAdviserAssigned, TaskListStatus expectedTaskListStatus)
+        [Theory, MemberData(nameof(CheckAllocateAdviserTaskListStatusCases))]
+        public void CheckAllocateAdviserTaskListStatusShouldReturnCorrectStatus(string? adviserEmailAddress, DateTime? dateAdviserAllocated, TaskListStatus expectedTaskListStatus)
         {
             // Arrange
-            var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(1, DateTime.Now, DateAdviserAssigned: dateAdviserAssigned, AdviserEmailAddress: adviserEmailAddress));
+            var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(1, DateTime.Now, DateAdviserAllocated: dateAdviserAllocated, AdviserEmailAddress: adviserEmailAddress));
 
             //Action 
-            var taskListStatus = TaskStatusViewModel.CheckAssignAdviserTaskListStatus(supportProjectModel);
+            var taskListStatus = TaskStatusViewModel.CheckAllocateAdviserTaskListStatus(supportProjectModel);
 
             //Assert
             Assert.Equal(expectedTaskListStatus, taskListStatus);


### PR DESCRIPTION
Due to confusion with assigning a delivery officer to a school, we are changing the language around assigning an adviser to try and clarify this.

The "Assign an adviser" task should now reference the allocation of an adviser.

--

# Before

![Screenshot 2025-03-04 at 3 07 46 pm](https://github.com/user-attachments/assets/f24c8a66-5fb8-46e9-a60c-82ed0a950d96)

![Screenshot 2025-03-04 at 3 07 54 pm](https://github.com/user-attachments/assets/2e692c4d-b2ee-4f2c-a4d1-8a526993e4bd)

--


# After

![Screenshot 2025-03-04 at 3 07 17 pm](https://github.com/user-attachments/assets/c85b0b85-306c-4594-a154-5c9cbf21a295)

![Screenshot 2025-03-04 at 3 07 26 pm](https://github.com/user-attachments/assets/449abbdd-275c-4675-b2c2-bba2ea3983d2)

