### PR TITLE
Making minor content changes to tasks following design crit

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AdviserConflictOfInterest/AdviserConflictOfInterest.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AdviserConflictOfInterest/AdviserConflictOfInterest.cshtml
@@ -23,7 +23,7 @@
         <h1 class="govuk-heading-l">
             Check potential adviser conflicts of interest
         </h1>
-        <p class="govuk-body">Check for conflicts of interest the potential adviser may have. For example, if the potential adviser used to work for the school or trust involved.</p>
+        <p class="govuk-body">For example, if the potential adviser used to work for the school or trust involved.</p>
         <form method="post" novalidate>
             <govuk-checkbox-input label="Send conflict of interest form to proposed adviser and the school" id="send-conflict-of-interest-form-to-proposed-adviser-and-the-school" name="send-conflict-of-interest-form-to-proposed-adviser-and-the-school" asp-for="@Model.SendConflictOfInterestFormToProposedAdviserAndTheSchool" />
             <govuk-checkbox-input label="Receive completed conflict of interest form" id="receive-completed-conflict-of-interest-form" name="receive-completed-conflict-of-interest-form" asp-for="@Model.ReceiveCompletedConflictOfInterestForm" />

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml
@@ -33,7 +33,7 @@
                 <div class="govuk-form-group @(Model.AdviserEmailAddressError ? "govuk-form-group--error" : "")">
                     <h2 class="govuk-label-wrapper">
                         <label class="govuk-label govuk-label--m" for="email-label">
-                            Email Address
+                            Email address
                         </label>
                     </h2>
                     <div id="email-hint" class="govuk-hint">

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ConfirmPlanningGrantOfferLetterSent/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ConfirmPlanningGrantOfferLetterSent/Index.cshtml
@@ -21,7 +21,7 @@
             Confirm planning grant offer letter sent
         </h1>
         <form method="post" novalidate>
-            <p class="govuk-body" data-cy="school-confirmtion-target-support">The grant team should have copied you into the email they send the supporting organisation and the school's responsible body.</p>
+            <p class="govuk-body" data-cy="school-confirmtion-target-support">The grant team send the grant offer letter by email to the supporting organisation and the responsible body. You should be copied in.</p>
             <govuk-date-input heading-label="false" label="Enter date planning grant offer letter sent" id="planning-grant-offer-letter-sent-date" name="planning-grant-offer-letter-sent-date" asp-for="@Model.PlanningGrantOfferLetterSentDate" hint="For example, 1 7 2024."/>
             <button class="govuk-button" type="submit" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">
                 Save and return

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/DueDiligenceOnPreferredSupportingOrganisation/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/DueDiligenceOnPreferredSupportingOrganisation/Index.cshtml
@@ -23,7 +23,7 @@
         <h1 class="govuk-heading-l">
             Carry out due diligence on preferred supporting organisation
         </h1>
-        <p class="govuk-body">Make sure the organisation can provide the necessary support. Add a note to capture any important details.</p>
+        <p class="govuk-body">Make sure the organisation can provide the necessary support. You can add a project note if you need to capture any details.</p>
         <form method="post" novalidate>
             <govuk-checkbox-input label="Check the organisation has capacity and is willing to provide support to this school" id="check-organisation-has-capacity-and-willing-to-provide-support" name="check-organisation-has-capacity-and-willing-to-provide-support" asp-for="@Model.CheckOrganisationHasCapacityAndWillingToProvideSupport" />
             <govuk-checkbox-input label="Speak to trust relationship manager or local authority lead to check choice" id="speak-to-trust-relationship-manager-or-local-authority-lead-to-check-choice" name="speak-to-trust-relationship-manager-or-local-authority-lead-to-check-choice" asp-for="@Model.CheckChoiceWithTrustRelationshipManagerOrLaLead" />

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordTheSchoolResponse/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordTheSchoolResponse/Index.cshtml
@@ -23,7 +23,7 @@
         <form method="post" novalidate>
             <p class="govuk-body" data-cy="school-confirmtion-target-support">Confirm if the school wants to get targeted support or not.</p>
             <govuk-radiobuttons-input name="@nameof(Model.HasAcceeptedTargetedSupport)" radio-buttons="@Model.TargetedSupportRadioButtoons" asp-for="@Model.HasAcceeptedTargetedSupport" />
-            <govuk-checkbox-input heading="Save the schools response in SharePoint" heading-style="govuk-fieldset__legend--m" label="School's response saved in SharePoint" id="has-saved-school-response-in-sharepoint" name="has-saved-school-response-in-sharepoint" asp-for="@Model.HasSavedSchoolResponseinSharePoint" />
+            <govuk-checkbox-input heading="Save the school's response in SharePoint" heading-style="govuk-fieldset__legend--m" label="School's response saved in SharePoint" id="has-saved-school-response-in-sharepoint" name="has-saved-school-response-in-sharepoint" asp-for="@Model.HasSavedSchoolResponseinSharePoint" />
             <govuk-date-input heading-label="false" label="Enter date the school's response was saved in SharePoint" id="school-response-date" name="school-response-date" asp-for="@Model.SchoolResponseDate" hint="For example, 1 7 2024." />
             <button class="govuk-button" type="submit" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">
                 Save and return

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordVisitDateToVisitSchool/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordVisitDateToVisitSchool/Index.cshtml
@@ -20,7 +20,7 @@
         <h1 class="govuk-heading-l" data-cy="page-heading">
             Record date of visit to school
         </h1>
-        <p class="govuk-body" data-cy="instruction-to-advisor">Enter the date that the visit actually took place.</p>
+        <p class="govuk-body" data-cy="instruction-to-advisor">Enter the date the visit took place.</p>
         <form method="post" novalidate>
             <govuk-date-input heading-label="false" label="Enter the date of visit" id="school-visit-date" name="school-visit-date" asp-for="@Model.SchoolVisitDate" hint="For example, 1 7 2024." />
             <button class="govuk-button" type="submit" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">


### PR DESCRIPTION
This work covers some very minor content changes following feedback from some design crits that @SteveMilnes ran recently.

The [story and related tasks for this work](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Manage%20School%20Improvement%20(MSI)/Academies-and-Free-Schools-SIP/Get%20support%20for%20schools%20and%20trusts/Sprint%206%20-%20Q4?workitem=204364) are in DevOps.

They are to:

- Add missing apostrophe to second heading in Record the school's response task
- Remove first sentence of paragraph text in conflict of interest task
- Email Address becomes Email address in allocate adviser task
- Remove "actually" from date of visit task text
- Clarify where to add note in due diligence task
- Clarify paragraph text in planning grant offer letter sent task