### PR TITLE
Changes to page title, H1 and addition of <p> text

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/SchoolList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/SchoolList/Index.cshtml
@@ -1,17 +1,19 @@
-@page "/schools-requiring-improvement"
+@page "/schools-identified-for-targeted-intervention"
 @using Microsoft.Extensions.Configuration
 @model IndexModel
 @inject IConfiguration Configuration
 
 @{
     Layout = "_Layout";
-    ViewData["Title"] = "Schools requiring improvement";
+    ViewData["Title"] = "Schools identified for targeted intervention";
 }
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <h1 class="govuk-heading-xl" data-cy="select-heading">
-            Schools requiring improvement
+            Schools identified for targeted intervention
         </h1>
+        <p class="govuk-body">This list may include schools that are no longer eligible due to a recent inspection result.</p>
+        <p class="govuk-body">You can add more schools to this list.</p>        
         <a asp-page="/AddSchool/WhichSchoolNeedsHelp" role="button" draggable="false" class="govuk-button" data-module="govuk-button" data-cy="create_new_conversion_btn">
             Add a school
         </a>

--- a/src/Dfe.ManageSchoolImprovement/Program.cs
+++ b/src/Dfe.ManageSchoolImprovement/Program.cs
@@ -162,7 +162,7 @@ app.UseEndpoints(endpoints =>
 {
     endpoints.MapGet("/", context =>
     {
-        context.Response.Redirect("schools-requiring-improvement", false);
+        context.Response.Redirect("schools-identified-for-targeted-intervention", false);
         return Task.CompletedTask;
     });
     endpoints.MapRazorPages();


### PR DESCRIPTION
This work makes some changes to the `/SchoolList` page.

They are:

- Addition of paragraph text to explain what the list is and that a delivery officer can add schools to it
- New H1 for the page to accurately describe the contents of the list
- URL changes from `/schools-requiring-improvement` to `/schools-identified-for-targeted-intervention` to match new H1

It also updates the `Program.cs` file so that the application loads on the correct page following the URL change. 

## Before

![unchanged-list](https://github.com/user-attachments/assets/ec50979a-0cf2-4f73-88e9-4374ff616ba6)

## After

![changed-list](https://github.com/user-attachments/assets/ff122d16-6ce8-47c4-803f-b9317a6bc1de)
