### PR TITLE
Content changes to the accessibility statement

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/Public/AccessibilityStatement.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Public/AccessibilityStatement.cshtml
@@ -35,22 +35,31 @@
             <a class="govuk-link" target="_blank" href="https://mcmw.abilitynet.org.uk/" rel="noopener">AbilityNet (opens in a new tab)</a> has advice on making your device easier to use if you have a disability.
         </p>
 
+      <h2 class="govuk-heading-l">How accessible this website is</h2>
+
+      <p class="govuk-body">We know some parts of this website are not fully accessible:</p>
+
+      <ol class="govuk-list govuk-list--number">
+        <li>Task statuses are not read out by some screen readers. This means that some people using screen readers may miss some important information that other users can get through visual association.</li>
+        <li>Only the task links on the task list are selectable, rather than the whole row. This can make it harder for some users to open a task.</li>
+        <li>Main headings on some pages are contained within groups of elements. This means they may not be read out correctly by some screen readers.</li>
+      </ol>
+
       <h2 class="govuk-heading-l">Feedback and contact information </h2>
       <p class="govuk-body-m">
          If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille:
       </p>
-      <p class="govuk-body-m">
-            <span>email <a class="govuk-link" href="mailto:@Configuration["SupportEmail"]?subject=Prepare%20conversions%20and%20transfers:%20support%20query">@Configuration["SupportEmail"]</a></span>
-            <br />
-            <span>call 0370 000 2288</span>
-         </p> 
+      <ul class="govuk-list govuk-list--bullet">
+            <li>email <a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk?subject=Manage%20school%20improvement:%20support%20query">regionalservices.rg@education.gov.uk</a></li>
+            <li>call 0370 000 2288</li>
+      </ul> 
       <p class="govuk-body">
             We'll consider your request and get back to you in 2 working days.
         </p>
 
         <h2 class="govuk-heading-l">Reporting accessibility problems with this website</h2>
       <p class="govuk-body">
-            We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact us using the details provided above.
+            We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, email our service support team on <a class="govuk-link" href="mailto:regionalservices.rg@education.gov.uk?subject=Manage%20school%20improvement:%20support%20query">regionalservices.rg@education.gov.uk</a> or call 0370 000 2288.
         </p>
 
         <h2 class="govuk-heading-l">Enforcement procedure</h2>
@@ -68,7 +77,7 @@
 
       <h2 class="govuk-heading-l">Compliance status</h2>
       <p class="govuk-body">
-            This website is partially compliant with the WCAG (Web Content Accessibility Guidelines) version 2.1AA standard, due to the following non-compliances and the following exemptions.
+            This website is partially compliant with the WCAG (Web Content Accessibility Guidelines) version 2.2 AA standard, due to the following non-compliances and the following exemptions.
         </p>
 
       <h3 class="govuk-heading-m">Non-accessible content</h3>
@@ -80,26 +89,34 @@
         </h4>
       <ul class="govuk-list govuk-list--bullet">
             <li>information and relationships that are implied by visual formatting may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 1.3.1 (Info and Relationships) </li>
-            <li>on the project lists pages the project status is not provided in the same reading order for assistive technology users compared to sighted users. This fails WCAG 2.1 AA success criteria 1.3.2 (Meaningful Sequence) and 2.4.3 (Focus Order) </li>
-            <li>on some pages the link text doesn't explain the purpose of the link. This fails WCAG 2.1 AA success criteria 2.4.4 (Link Purpose, In Context) </li>
-            <li>main headings on some pages are contained within groups of elements and so may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels) </li>
+            <li>on the task list page the task status is not provided in the same reading order for assistive technology users compared to sighted users. This fails WCAG 2.1 AA success criteria 1.3.2 (Meaningful Sequence) and 2.4.3 (Focus Order) </li>
             <li>some information that is available to sighted users is not given to assistive technology users. This fails WCAG 2.1 AA success criteria 4.1.2 (Name, Role, Value) </li>
+            <li>main headings on some pages are contained within groups of elements and so may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels) </li>
       </ul>
         <h2 class="govuk-heading-m">What we're doing to improve accessibility</h2>
       <p class="govuk-body">
-            We are looking into the non-compliances mentioned previously and aim to resolve these in a future iteration of the website.
+            We are looking into the non-compliances and aim to fix them in a future iteration of the website.
         </p>
-
+      <p class="govuk-body">
+            We have work in our backlog to:
+        </p>
+      <ul class="govuk-list govuk-list--bullet">
+            <li>make screen readers announce task status when reading out the task link on the task list</li>
+            <li>enable entire rows of the task list to be selectable</li>
+            <li>ensure headings are readable by screen readers</li>
+      </ul>
         <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
       <p class="govuk-body">
-            This statement was prepared on 19 August 2022. It was last reviewed on 19 November 2024.
+            This statement was prepared on 26 March 2025. It was last reviewed on 26 March 2025.
         </p>
-        <p class="govuk-body">This website was last tested in August 2023. The test was carried out by <a target="_blank" href="https://nexerdigital.com" rel="noopener" class="govuk-link">Nexer Digital Ltd</a>.</p>
       <p class="govuk-body">
-            They tested the most frequently used pages within the website.
+        This website was last tested on 26 March 2025. The test was carried out by DfE's Technology Operations team.
         </p>
-        <p class="govuk-body">
-            Accessibility statement version: 2.0.0
+      <p class="govuk-body">
+        We tested all pages that followed a unique structure or design pattern. Where pages followed a replicated design pattern, such as tasks, we tested examples of each type of task pattern.
+        </p>
+      <p class="govuk-body">
+            Accessibility statement version: 1.0.0
         </p>
    </div>
 </div>


### PR DESCRIPTION
This work updates our accessibility statement.

## Changes:

- using DfE's partially compliant template to structure our statement, leaving out any irrelevant sections such as "disproportionate burden" as that does not apply to the work of a central government department or these specific known issues
- adding a 'How accessible this website is section' and listing known issues
- refining the list of details about the know issues
- adding planned actions to resolve the known issues
- correcting information about dates the statement was create
- correcting information about who audited the service and when
- adding information about which pages we chose to audit
- including an email address for feedback and contact information
- including an email address for reporting accessibility problems
- adding a mailto: link for those emails addresses and including a pre-filler subject so that emails sent to that address are filtered into the right folders for the support team

## Before

![accessibility-statement-as-is](https://github.com/user-attachments/assets/bea43185-390a-4fdc-8bbb-519bfdc38f17)

## After

![accessibility-statement-to-be](https://github.com/user-attachments/assets/f3c2a58f-43a2-4049-8b57-ffefa4608b8a)
