### PR TITLE
Removing irrelevant heading issue from accessibility statement

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/Public/AccessibilityStatement.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Public/AccessibilityStatement.cshtml
@@ -42,7 +42,6 @@
       <ol class="govuk-list govuk-list--number">
         <li>Task statuses are not read out by some screen readers. This means that some people using screen readers may miss some important information that other users can get through visual association.</li>
         <li>Only the task links on the task list are selectable, rather than the whole row. This can make it harder for some users to open a task.</li>
-        <li>Main headings on some pages are contained within groups of elements. This means they may not be read out correctly by some screen readers.</li>
         <li>Details components are used to provide additional guidance and information that is useful to some users but not essential for all. There is a known accessibility issue with the details component. It is a button that appears as a link. Some voice assist software might require the user to specifically refer to the link to show more details as a button in order to interact with it.</li>
         <li>The "Apply filters" button is at the top of the list of filters on the list of schools page. Users have to scroll back up or navigate back up the page with keyboard commands to select it. This makes it cumbersome to filter information.</li>
         <li>When allocating an advisor and entering an email address, an error message appears if the user does not enter "rise." at the beginning of the email address. Hint text here could be clearer. This may cause confusion for some users.</li>
@@ -94,7 +93,6 @@
             <li>information and relationships that are implied by visual formatting may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 1.3.1 (Info and Relationships)</li>
             <li>on the task list page the task status is not provided in the same reading order for assistive technology users compared to sighted users. This fails WCAG 2.1 AA success criteria 1.3.2 (Meaningful Sequence) and 2.4.3 (Focus Order)</li>
             <li>some information that is available to sighted users is not given to assistive technology users. This fails WCAG 2.1 AA success criteria 4.1.2 (Name, Role, Value)</li>
-            <li>main headings on some pages are contained within groups of elements and so may not be read out correctly by some screen readers. This fails WCAG 2.1 AA success criteria 2.4.6 (Headings and Labels)</li>
       </ul>
         <h2 class="govuk-heading-m">What we're doing to improve accessibility</h2>
       <p class="govuk-body">
@@ -106,14 +104,13 @@
       <ul class="govuk-list govuk-list--bullet">
             <li>make screen readers announce task status when reading out the task link on the task list</li>
             <li>enable entire rows of the task list to be selectable</li>
-            <li>ensure all headings are readable by screen readers</li>
             <li>explore different design options for content in details components</li>
             <li>move the "Apply filters" button to the bottom of the list of filters and feed this back to the DfE patterns and components working group</li>
             <li>clarify hint text in the Allocate an adviser task to make the required email format clearer to users</li>
       </ul>
         <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
       <p class="govuk-body">
-            This statement was prepared on 26 March 2025. It was last reviewed on 28 March 2025.
+            This statement was prepared on 26 March 2025. It was last reviewed on 3 April 2025.
         </p>
       <p class="govuk-body">
         This website was last tested on 26 March 2025. The test was carried out by DfE's Technology Operations team.


### PR DESCRIPTION
This work removes references to a potential issue with headings not being readable by screen readers. It also updates the date the accessibility statement was last review to today's date.

The heading issue has been checked, twice, and is not a problem. Therefore the accessibility statement content can be updated to reflect this.

## Before

![test manage-school-improvement education gov uk_public_accessibility](https://github.com/user-attachments/assets/7ee5e741-06df-4a37-9d9c-8e9c339dfa09)

## After

![localhost_7088_public_accessibility](https://github.com/user-attachments/assets/f1c7570e-0cdc-4df9-bc37-8df7f1de15f7)
