### PR TITLE
Fixed typscript errors in tsconfig.json by removing un-needed xlsx ty…

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/tsconfig.json
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/tsconfig.json
@@ -51,7 +51,7 @@
         // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
         // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
         // "removeComments": true,                           /* Disable emitting comments. */
-        // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+        "noEmit": true,                                   /* Disable emitting files from a compilation. */
         // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
         // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
         // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
@@ -102,6 +102,6 @@
         "baseUrl": "./",
         "moduleResolution": "node",
         "lib": ["esnext", "dom"],
-        "types": ["cypress", "cypress-axe", "node", "xlsx","@cypress/grep"]
+        "types": ["cypress", "cypress-axe", "node", "@cypress/grep"]
     }
 }


### PR DESCRIPTION
…pe & set noEmit to true to stop a JS from being created from a JS from generateZapReport