### PR TITLE
Request improvement grant offer letter task content changes

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RequestImprovementGrantOfferLetter/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RequestImprovementGrantOfferLetter/Index.cshtml
@@ -20,7 +20,7 @@
         <h1 class="govuk-heading-l" data-cy="page-heading">
             Request improvement grant offer letter
         </h1>
-        <p class="govuk-body" data-cy="instruction-to-adviser">Email the grant team at <a class="govuk-link" href="mailto:@Model.EmailAddress">@Model.EmailAddress</a> and ask them to send the improvement grant offer letter to the school's responsible body.</p>
+        <p class="govuk-body" data-cy="instruction-to-adviser">Email the grant team at <a class="govuk-link" href="mailto:@Model.EmailAddress">@Model.EmailAddress</a> and ask them to send the improvement grant offer letter to the school.</p>
         <form method="post" novalidate>
             <govuk-checkbox-input label="Include the required contact details in the email" label-hint="Make sure you add the contacts the grant team need to this project." id="include-contact-details" name="include-contact-details" asp-for="@Model.IncludeContactDetails" />
             <details class="govuk-details">
@@ -30,7 +30,7 @@
                     </span>
                 </summary>
                 <div class="govuk-details__text">
-                    <h2 class="govuk-heading-m">Responsible body of school</h2>
+                    <h2 class="govuk-heading-m">School</h2>
                     <p>You must add the contact details for the school's chief accounting officer, or equivalent.</p>
                     <p>For academies this is usually the CEO of the trust. For local authority maintained schools, this is usually the headteacher.</p>
                     <p>You must include their:</p>

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RequestPlanningGrantOfferLetter/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RequestPlanningGrantOfferLetter/Index.cshtml
@@ -23,7 +23,7 @@
         <h1 class="govuk-heading-l">
             Request planning grant offer letter 
         </h1>
-        <p class="govuk-body">Email the grant team at <a class="govuk-link" href="mailto:@Model.EmailAddress">@Model.EmailAddress</a> and ask them to send the planning grant offer letter to the supporting organisation and responsible body.</p>
+        <p class="govuk-body">Email the grant team at <a class="govuk-link" href="mailto:@Model.EmailAddress">@Model.EmailAddress</a> and ask them to send the planning grant offer letter to the supporting organisation and copy in the school.</p>
         <form method="post" novalidate>
             <govuk-checkbox-input label-hint="Make sure you add the contacts the grant team need to this project." label="Include the required contact details in the email" id="include-contact-details" name="include-contact-details" asp-for="@Model.IncludeContactDetails"/>
             <details class="govuk-details">
@@ -41,8 +41,8 @@
                         <li>postal address</li>
                     </ul>
                     <p>Contact the grant team if you're not sure who this is.</p>
-                    <h2 class="govuk-heading-m">Responsible body</h2>
-                    <p>You should also include the contact details of the school's responsible body.</p>
+                    <h2 class="govuk-heading-m">School</h2>
+                    <p>You should also include the contact details of the school.</p>
                     <p>For local authority maintained schools, you must include a name and email address for:</p>
                     <ul>
                         <li>headteacher</li>


### PR DESCRIPTION
This work includes minor changes to content in the 'Request improvement grant offer letter' task follow feedback from the Grants team.

Rather than the 'responsible body' we now refer to the 'school'.

# Before

![improvement-gol-before](https://github.com/user-attachments/assets/14ea23cc-8017-4d87-83d6-548a712a9b2d)


# After

![improvement-gol-after](https://github.com/user-attachments/assets/986a2e2e-9b00-43c8-b0e6-8921a415dd06)
