### PR TITLE
issue 210538 - css override to align task list status tag to the left 

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/wwwroot/src/index.scss
+++ b/src/Dfe.ManageSchoolImprovement/wwwroot/src/index.scss
@@ -14,6 +14,13 @@ $govuk-font-family: "Inter", blinkmacsystemfont, "Segoe UI", roboto, oxygen-sans
 .govuk-tag{
 	max-width: none !important;
 }
+.govuk-task-list__status{
+
+	text-align: left !important;
+}
+.govuk-task-list__status .govuk-tag {
+	float: right !important;
+}
 
 .moj-sub-navigation__item {
 	margin-bottom: 0;


### PR DESCRIPTION
- css override to align task list status tag to the left when in screen/window is rdeuced