### PR TITLE
Add tests for filters

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/applyFilters.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/applyFilters.cy.ts
@@ -6,35 +6,90 @@ describe("User search results by appliying filters", () => {
         cy.login();
     });
 
-    it("should show the success notification banner when a region filter is applied", () => {
+    afterEach(() => {
+        Logger.log("Clear Filters");
+        homePage.clearFilters()
+    });
+
+    it("should show results successfully on selecting multiple projects", () => {
         homePage
             .hasProjectFilter()
             .selectEastMidlandsRegionFilter()
             .applyFilters()
             .hasFilterSuccessNotification()
+
+        //  cy.executeAccessibilityTests() commented accessibility due to bug #209930
     });
 
-    it("should filter projects by region", () => {
-        cy.executeAccessibilityTests()
-
-        Logger.log("Testing we can filter projects by region...");
+    it("should show the expected filtered results", () => {
+        Logger.log("Testing-filter projects by region");
         homePage
-          .withFilterRegions()
-           .hasFilterRegions()
+            .selectFilterRegions()
+            .applyFilters()
+            .hasFilterSuccessNotification()
+            .hasFilterRegions()
 
-        Logger.log("Clearing Filters...");
-        homePage.clearFilters()
+        //  cy.executeAccessibilityTests()
     });
 
     it("should filter projects by school name", () => {
-        cy.executeAccessibilityTests()
-
-        Logger.log("Testing we can filter projects by inputting schoolname...");
+        Logger.log("Testing- filter projects by providing schoolname");
         homePage
-          .withProjectFilter("Outwood Academy Shafton")
-          .hasSchoolName("Outwood Academy Shafton")
+            .selectProjectFilter("Outwood Academy Shafton")
+            .applyFilters()
+            .hasFilterSuccessNotification()
+            .hasSchoolName("Outwood Academy Shafton")
 
-        Logger.log("Clearing Filters...");
-        homePage.clearFilters()
+        //  cy.executeAccessibilityTests()
+    });
+
+       it("should filter projects by URN", () => {
+        Logger.log("Testing- filter projects by providing URN");
+        homePage
+            .selectProjectFilter("105443")
+            .applyFilters()
+            .hasFilterSuccessNotification()
+            .hasURN("105443")
+
+        //  cy.executeAccessibilityTests()
+    }); 
+
+    it("should filter projects by Assigned to", () => {
+        Logger.log("Testing - filter projects by Assigned to");
+        homePage
+            .selectAssignedToFilter("Richika Dogra")
+            .applyFilters()
+            .hasFilterSuccessNotification()
+
+        //  cy.executeAccessibilityTests()
+    });
+
+    it("should filter projects by Not Assigned to", () => {
+        Logger.log("Testing - filter projects by Assigned to");
+        homePage
+            .selectNotAssignedToFilter()
+            .applyFilters()
+            .hasFilterSuccessNotification()
+
+        //  cy.executeAccessibilityTests()
+    });
+
+    it("should show/hide all the filter sections", () => {
+        Logger.log("Testing - filter projects by Assigned to");
+        homePage
+            .showAllFilterSections()
+            .hideAllFilterSections()
+
+        //  cy.executeAccessibilityTests()
+    });
+
+    it("should show all the results when no filter is selected", () => {
+        Logger.log("Testing - filter projects by Assigned to");
+        homePage
+            .applyFilters()
+            .noFiltersSelected()
+            .resultCountNotZero()
+
+        //  cy.executeAccessibilityTests()
     });
 });

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/homePage.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/homePage.ts
@@ -37,10 +37,27 @@ class HomePage {
     return this;
   }
 
-  public withProjectFilter(project: string): this {
+  public selectProjectFilter(project: string): this {
     cy.get('[data-cy="select-projectlist-filter-title"]').typeFast(project);
     cy.get('[data-cy="select-projectlist-filter-apply"]').click();
-    
+
+    return this;
+  }
+
+  public selectAssignedToFilter(assignedTo: string): this {
+    // cy.get('[data-cy="select-projectlist-filter-assignedTo"]') //need to apply in code
+    cy.get('#accordion-officers-heading').should('contain', 'Assigned to').click()
+    cy.get('#filter-delivery-officer-not-assigned')
+    cy.get('.govuk-accordion__section-content .govuk-checkboxes')
+      .contains(assignedTo.trim())
+      .click();
+    return this;
+  }
+
+  public selectNotAssignedToFilter(): this {
+    cy.get('#accordion-officers-heading').should('contain', 'Assigned to').click()
+    cy.get('#filter-delivery-officer-not-assigned')
+    cy.get('[data-cy="select-projectlist-filter-officer-not-assigned"]').click()
     return this;
   }
 
@@ -71,8 +88,14 @@ class HomePage {
 
   public applyFilters(): this {
     cy.get('[data-cy="select-projectlist-filter-apply"]').click();
-    
+
     return this;
+  }
+
+  public noFiltersSelected(): this {
+    cy.get('.moj-filter__selected').should('contain.text', 'No filters selected')
+
+    return this
   }
 
   public selectSchool(schoolLong: string): this {
@@ -81,13 +104,19 @@ class HomePage {
     return this;
   }
 
-  public hasSchoolName(schoolLong: string) : this {
+  public hasSchoolName(schoolLong: string): this {
     cy.get('[data-cy="trust-name-0"]').contains(schoolLong);
 
     return this;
   }
 
-  public selectSchoolName(schoolLong: string) : this {
+  public hasAssignedToOption(assignedTo: string): this {
+    cy.get('[data-cy="assigned-to-0"]').contains(assignedTo);
+
+    return this;
+  }
+
+  public selectSchoolName(schoolLong: string): this {
     cy.get('[data-cy^="trust-name-"]').contains(schoolLong).click();
 
     return this;
@@ -112,7 +141,8 @@ class HomePage {
   }
 
   public hasFilterSuccessNotification(): this {
-    cy.get('[data-cy="filter-success-notification"]').should("be.visible");
+    cy.get('[data-cy="filter-success-notification"]').should("be.visible")
+    cy.get('#govuk-notification-banner-title').should('contain', 'Success')
 
     return this;
   }
@@ -123,7 +153,23 @@ class HomePage {
     return this;
   }
 
-  public withFilterRegions(): this {
+  public showAllFilterSections(): this {
+    cy.get('.govuk-accordion__show-all-text').should('contain.text', 'Show all sections')
+      .click()
+    cy.get('.govuk-accordion__show-all-text').should('contain.text', 'Hide all sections')
+
+    return this;
+  }
+
+  public hideAllFilterSections(): this {
+    cy.get('.govuk-accordion__show-all-text').should('contain.text', 'Hide all sections')
+      .click()
+    cy.get('.govuk-accordion__show-all-text').should('contain.text', 'Show all sections')
+
+    return this;
+  }
+
+  public selectFilterRegions(): this {
     // Check if the Region accordion section is not expanded
     cy.get('[data-cy="select-projectlist-filter-region"]')
       .should("have.attr", "aria-expanded", "false")
@@ -138,9 +184,6 @@ class HomePage {
     cy.get("#filter-project-region-east-of-england").check();
     cy.get("#filter-project-region-london").check();
     cy.get("#filter-project-region-north-east").check();
-
-    // Apply the filters
-    cy.get('[data-cy="select-projectlist-filter-apply"]').click();
 
     return this;
   }
@@ -166,14 +209,16 @@ class HomePage {
 
   public clearFilters(): this {
     // Clear the filters
-    cy.get('[data-cy="clear-filter"]').click();
+    cy.get('[data-cy="clear-filter"]').should('be.visible')
+      .click();
+    cy.url().should('contain', 'clear')
 
     return this;
   }
 
   public resultCountNotZero(): this {
     cy.get('[data-cy="trust-name-0"]').should('be.visible')
-     cy.contains(/schools found/i)
+    cy.contains(/schools found/i)
       .invoke('text')
       .then((text: string) => {
         // Use regex to extract the number from the string
@@ -185,7 +230,7 @@ class HomePage {
 
         // Assert that the school count is not zero
         expect(schoolCount).to.be.greaterThan(0);
-        
+
       });
     return this;
   }


### PR DESCRIPTION
This PR includes : 
- tests for msi filters
- bit of refinement
- accessibility check has been commented atm due to an existing bug #209930
- Also the cypress selectors are not defined for every cta so would be good to request/esclate to Dev to please consider cypress selectors while building FE pages specially for all cta's (thus those will be updated once implemented)
![Cypress_apply filters](https://github.com/user-attachments/assets/5dd6d17b-d9bf-489a-ac50-f8187eff7fbb)
