### PR TITLE
Content changes to adviser visit tasks

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/smoke/smoke-end-to-end-create-project.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/smoke/smoke-end-to-end-create-project.cy.ts
@@ -179,17 +179,17 @@ describe("User completes their newly created project", () => {
     taskList.hasFilterSuccessNotification()
       .hasTaskStatusCompleted("send-introductory-email-request-improvement-plan_status");
 
-    Logger.log("Selecting 'Arrange adviser's first face-to-face visit' task");
-    taskList.selectTask("Arrange adviser's first face-to-face visit");
-    taskListActions.hasHeader("Arrange adviser's first face-to-face visit");
+    Logger.log("Selecting 'Arrange adviser's initial visit' task");
+    taskList.selectTask("Arrange adviser's initial visit");
+    taskListActions.hasHeader("Arrange adviser's initial visit");
     taskListActions.enterDate("adviser-visit-date", "01", "01", "2024");
     taskListActions.selectButtonOrCheckbox("save-and-continue-button");
     taskList.hasFilterSuccessNotification()
       .hasTaskStatusCompleted("adviser-school-visit_status");
 
-    Logger.log("Selecting 'Record date of visit to school' task");
-    taskList.selectTask("Record date of visit to school");
-    taskListActions.hasHeader("Record date of visit to school");
+    Logger.log("Selecting 'Record date of initial visit' task");
+    taskList.selectTask("Record date of initial visit");
+    taskListActions.hasHeader("Record date of initial visit");
     taskListActions.enterDate("school-visit-date", "01", "01", "2024");
     taskListActions.selectButtonOrCheckbox("save-and-continue-button");
     taskList.hasFilterSuccessNotification()

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
@@ -78,8 +78,8 @@ class TaskList {
     cy.contains('Check potential adviser conflicts of interest');
     cy.contains('Allocate an adviser');
     cy.contains('Send introductory email');
-    cy.contains("Arrange adviser's first face-to-face visit");
-    cy.contains('Record date of visit to school');
+    cy.contains("Arrange adviser's initial visit");
+    cy.contains('Record date of initial visit');
     cy.contains('Write and save the Note of Visit');
     cy.contains('Complete and save the assessment template');
     cy.contains('Record matching decision');

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ArrangeAdvisersFirstFaceToFaceVisit/ArrangeAdvisersFirstFaceToFaceVisit.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ArrangeAdvisersFirstFaceToFaceVisit/ArrangeAdvisersFirstFaceToFaceVisit.cshtml
@@ -1,8 +1,8 @@
-@page "/task-list/arrange-advisers-first-face-to-face-visit/{id:int}"
+@page "/task-list/arrange-advisers-initial-visit/{id:int}"
 @model             ArrangeAdvisersFirstFaceToFaceVisitModel
 
 @{
-    ViewData["Title"] = "Arrange adviser's first face-to-face visit";
+    ViewData["Title"] = "Arrange adviser's initial visit";
 }
 
 @section BeforeMain
@@ -19,9 +19,10 @@
 <div class="govuk-grid-column-two-thirds">
     <span class="govuk-caption-l">@Model.SupportProject.SchoolName</span>
     <h1 class="govuk-heading-l">
-            Arrange adviser's first face-to-face visit
+            Arrange adviser's initial visit
     </h1>
-        <p class="govuk-body">Work with the adviser and school to find a date and time for the adviser to make their first face-to-face visit to the school.</p>
+        <p class="govuk-body">Work with the adviser and school to find a date and time for the adviser to make their initial visit.</p>
+        <p class="govuk-body">It can take place in-person or remotely.</p>
         <p class="govuk-body">The length of the visit may change depending on the needs of the school.</p>
         
     <form method="post" novalidate>

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -133,7 +133,7 @@
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link" asp-page="@Links.TaskList.ArrangeAdvisersFirstFaceToFaceVisit.Page" asp-route-id="@Model.SupportProject.Id" data-cy="adviser-school-visit" aria-describedby="adviser-school-visit_status">
-                            Arrange adviser's first face-to-face visit
+                            Arrange adviser's initial visit
                         </a>
                     </div>
                     <div class="govuk-task-list__status" id="adviser-school-visit_status">
@@ -143,7 +143,7 @@
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link" asp-page="@Links.TaskList.RecordVisitDateToVisitSchool.Page" asp-route-id="@Model.SupportProject.Id" data-cy="record-school-visit-date" aria-describedby="record-school-visit-date_status">
-                            Record date of visit to school
+                            Record date of initial visit
                         </a>
                     </div>
                     <div class="govuk-task-list__status" id="record-school-visit-date_status">

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordVisitDateToVisitSchool/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordVisitDateToVisitSchool/Index.cshtml
@@ -1,7 +1,7 @@
-@page "/task-list/record-visit-date-to-school/{id:int}"
+@page "/task-list/record-date-initial-visit/{id:int}"
 @model Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordVisitDateToVisitSchool.IndexModel
 @{
-    ViewData["Title"] = "Record date of visit to school";
+    ViewData["Title"] = "Record date of initial visit";
 }
 
 @section BeforeMain
@@ -18,9 +18,9 @@
     <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l" data-cy="school-name">@Model.SupportProject.SchoolName</span>
         <h1 class="govuk-heading-l" data-cy="page-heading">
-            Record date of visit to school
+            Record date of initial visit
         </h1>
-        <p class="govuk-body" data-cy="instruction-to-advisor">Enter the date the visit took place.</p>
+        <p class="govuk-body" data-cy="instruction-to-advisor">Enter the date the visit took place. It may have been in-person or remote.</p>
         <form method="post" novalidate>
             <govuk-date-input heading-label="false" label="Enter the date of visit" id="school-visit-date" name="school-visit-date" asp-for="@Model.SchoolVisitDate" hint="For example, 1 7 2024." />
             <button class="govuk-button" type="submit" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">


### PR DESCRIPTION
This work updates content in the following tasks:

- Arrange adviser's first face-to-face visit
- Record date of visit to school
 
Changes include: 

- removal of references to visits only happening face-to-face
- introduction of conte to explain visits can happen in-person or remotely- 
- changes task names on task pages and in the task list
- changes to task URLs to match H1s
- updated references to the previous task names and URLs in smoke tests

## Task list before

![Screenshot 2025-06-18 at 9 04 21 am](https://github.com/user-attachments/assets/6c6e2c28-5e90-4602-972f-56aa8940e6bf)

## Task list after

![Screenshot 2025-06-18 at 9 25 20 am](https://github.com/user-attachments/assets/7f08b3b6-76f6-4038-bf04-c5c72a837543)

## Arrange visit task before

![Screenshot 2025-06-18 at 9 04 28 am](https://github.com/user-attachments/assets/e6cd094b-a5b9-4d21-8c02-e8e72107aca9)

## Arrange visit task after

![Screenshot 2025-06-18 at 9 06 28 am](https://github.com/user-attachments/assets/4ddef885-69fe-4153-86a2-45836311e04a)

## Record date of visit task before

![Screenshot 2025-06-18 at 9 04 36 am](https://github.com/user-attachments/assets/96296a36-dd7d-415f-8dbd-ece4323aae04)

## Record date of visit task after

![Screenshot 2025-06-18 at 9 21 47 am](https://github.com/user-attachments/assets/5d75e349-4db2-40fc-be77-512f12c3143e)
