### PR TITLE
Assessment tool two confirmation added

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetChoosePreferredSupportingOrganisation.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetChoosePreferredSupportingOrganisation.cs
@@ -1,6 +1,5 @@
 using Dfe.ManageSchoolImprovement.Domain.Interfaces.Repositories;
 using Dfe.ManageSchoolImprovement.Domain.ValueObjects;
-using Dfe.ManageSchoolImprovement.Utils;
 using MediatR;
 
 namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.UpdateSupportProject;
@@ -8,9 +7,10 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.Update
 
 public record SetChoosePreferredSupportingOrganisationCommand(
     SupportProjectId SupportProjectId,
-    string? OrganisationName ,
+    string? OrganisationName,
     string? IDNumber,
-    DateTime? DateSupportOrganisationChosen
+    DateTime? DateSupportOrganisationChosen,
+    bool? AssessmentToolTwoCompleted
 ) : IRequest<bool>;
 public class SetChoosePreferredSupportingOrganisation
 {
@@ -30,7 +30,8 @@ public class SetChoosePreferredSupportingOrganisation
 
             supportProject.SetChoosePreferredSupportOrganisation(request.DateSupportOrganisationChosen,
                 request.OrganisationName,
-                request.IDNumber);
+                request.IDNumber,
+                request.AssessmentToolTwoCompleted);
 
             await supportProjectRepository.UpdateAsync(supportProject, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
@@ -93,7 +93,8 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Models
         DateTime? EngagementConcernRaisedDate = null,
         bool? InformationPowersInUse = null,
         string? InformationPowersDetails = null,
-        DateTime? PowersUsedDate = null
+        DateTime? PowersUsedDate = null,
+        bool? AssessmentToolTwoCompleted = null
     )
     { }
 }

--- a/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
+++ b/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
@@ -66,8 +66,9 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
 
     public DateTime? SchoolResponseDate { get; private set; }
 
-    public bool? 
-        HasAcknowledgedAndWillEngage { get; private set; }
+    public bool?
+        HasAcknowledgedAndWillEngage
+    { get; private set; }
 
     public bool? HasSavedSchoolResponseinSharePoint { get; private set; }
 
@@ -101,7 +102,7 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
     public string? SupportOrganisationName { get; private set; }
 
     public string? SupportOrganisationIdNumber { get; private set; }
-
+    public bool? AssessmentToolTwoCompleted { get; private set; }
     public DateTime? RegionalDirectorDecisionDate { get; private set; }
 
     public bool? HasSchoolMatchedWithSupportingOrganisation { get; private set; }
@@ -173,15 +174,15 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
     public bool? EngagementConcernRecorded { get; private set; }
 
     public string? EngagementConcernDetails { get; private set; }
-    
+
     public bool? EngagementConcernEscalationConfirmStepsTaken { get; private set; }
-    
+
     public string? EngagementConcernEscalationPrimaryReason { get; private set; }
-    
+
     public string? EngagementConcernEscalationDetails { get; private set; }
-    
+
     public DateTime? EngagementConcernEscalationDateOfDecision { get; private set; }
-    
+
     public DateTime? EngagementConcernRaisedDate { get; private set; }
 
     public IEnumerable<FundingHistory> FundingHistories => _fundingHistories.AsReadOnly();
@@ -317,11 +318,13 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
 
     public void SetChoosePreferredSupportOrganisation(DateTime? dateSupportOrganisationChosen,
         string? supportOrganisationName,
-        string? supportOrganisationIdNumber)
+        string? supportOrganisationIdNumber,
+        bool? assessmentToolTwoCompleted)
     {
         DateSupportOrganisationChosen = dateSupportOrganisationChosen;
         SupportOrganisationName = supportOrganisationName;
         SupportOrganisationIdNumber = supportOrganisationIdNumber;
+        AssessmentToolTwoCompleted = assessmentToolTwoCompleted;
     }
 
     public void SetRecordMatchingDecision(DateTime? regionalDirectorDecisionDate, bool? hasSchoolMatchedWithSupportingOrganisation, string? notMatchingSchoolWithSupportingOrgNotes)

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250619134200_assessment-tool-two-completed.Designer.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250619134200_assessment-tool-two-completed.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageSchoolImprovement.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
 {
     [DbContext(typeof(RegionalImprovementForStandardsAndExcellenceContext))]
-    partial class RegionalImprovementForStandardsAndExcellenceContextModelSnapshot : ModelSnapshot
+    [Migration("20250619134200_assessment-tool-two-completed")]
+    partial class assessmenttooltwocompleted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250619134200_assessment-tool-two-completed.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250619134200_assessment-tool-two-completed.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class assessmenttooltwocompleted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AssessmentToolTwoCompleted",
+                schema: "RISE",
+                table: "SupportProject",
+                type: "bit",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AssessmentToolTwoCompleted",
+                schema: "RISE",
+                table: "SupportProject")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+    }
+}

--- a/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
@@ -165,21 +165,22 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
         public bool? CopyInRegionalDirector { get; set; }
 
         public bool? SendEmailToGrantTeam { get; set; }
-        
+
         public bool? EngagementConcernEscalationConfirmStepsTaken { get; set; }
-        
+
         public string? EngagementConcernEscalationPrimaryReason { get; set; }
-        
+
         public string? EngagementConcernEscalationDetails { get; set; }
-        
+
         public DateTime? EngagementConcernEscalationDateOfDecision { get; set; }
-        
+
         public DateTime? EngagementConcernRaisedDate { get; set; }
 
         public bool? InformationPowersInUse { get; set; }
         public string? InformationPowersDetails { get; set; }
         public DateTime? PowersUsedDate { get; set; }
-        
+        public bool? AssessmentToolTwoCompleted { get; set; }
+
         public static SupportProjectViewModel Create(SupportProjectDto supportProjectDto)
         {
             return new SupportProjectViewModel()
@@ -284,7 +285,8 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
                 EngagementConcernRaisedDate = supportProjectDto.EngagementConcernRaisedDate,
                 InformationPowersInUse = supportProjectDto.InformationPowersInUse,
                 InformationPowersDetails = supportProjectDto.InformationPowersDetails,
-                PowersUsedDate = supportProjectDto.PowersUsedDate
+                PowersUsedDate = supportProjectDto.PowersUsedDate,
+                AssessmentToolTwoCompleted = supportProjectDto.AssessmentToolTwoCompleted
             };
         }
     }

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml
@@ -1,6 +1,6 @@
 @page "/task-list/choose-preferred-supporting-organisation/{id:int}"
 @model Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.ChoosePreferredSupportingOrganisation.IndexModel
-
+@inject IConfiguration Configuration
 @{
     ViewData["Title"] = "Choose preferred supporting organisation";
 }
@@ -40,12 +40,12 @@
                             <span id="complete-assessment-tool-hint" class="govuk-hint">
                                 You must download a
                                 <a class="govuk-link"
-                                   href="#"
+                                   href="@Configuration["AssessmentToolTwoLink"]"
                                    rel="noreferrer noopener"
                                    target="_blank">copy of the assessment tool (opens in new tab)</a>.
                                 When complete
                                 <a class="govuk-link"
-                                   href="#"
+                                   href="@Configuration["AssessmentToolTwoSharePointFolderLink"]"
                                    rel="noreferrer noopener"
                                    target="_blank">upload it to the relevant region's assessment folder in SharePoint (opens in new tab)</a>.
                             </span>

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml
@@ -24,6 +24,37 @@
         <p class="govuk-body">The support organisation is not confirmed until the school and regional director both agree to the choice.</p>
         
         <form method="post" novalidate>
+            <div class="govuk-form-group">
+                <div class="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                        <input name="complete-assessment-tool-hidden" type="hidden" value="false" />
+                        <input class="govuk-checkboxes__input"
+                               id="complete-assessment-tool"
+                               name="complete-assessment-tool"
+                               type="checkbox"
+                               value="true"
+                               checked="@Model.CompleteAssessmentTool">
+                        <label class="govuk-label govuk-checkboxes__label" for="complete-assessment-tool">
+                            Complete assessment tool 2: Selecting a supporting organisation
+                            <br />
+                            <span id="complete-assessment-tool-hint" class="govuk-hint">
+                                You must download a
+                                <a class="govuk-link"
+                                   href="#"
+                                   rel="noreferrer noopener"
+                                   target="_blank">copy of the assessment tool (opens in new tab)</a>.
+                                When complete
+                                <a class="govuk-link"
+                                   href="#"
+                                   rel="noreferrer noopener"
+                                   target="_blank">upload it to the relevant region's assessment folder in SharePoint (opens in new tab)</a>.
+                            </span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+
             <govuk-text-input heading-label="true" label="Name" id="organisation-name" name="organisation-name" asp-for="@Model.OrganisationName" width="30"/>
             <govuk-text-input heading-label="true" label="ID number" hint="If the supporting organisation is a trust, enter the UKPRN. If it is a local authority, enter its LAESTAB." id="id-number" name="id-number" asp-for="@Model.IdNumber" width="30"/>
             <govuk-date-input heading-label="false" label="Enter date preferred supporting organisation chosen" id="date-support-organisation-chosen" name="date-support-organisation-chosen" asp-for="@Model.DateSupportOrganisationChosen" hint="For example, 1 7 2024."/>

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml.cs
@@ -8,24 +8,25 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.ChoosePreferredSupportingOrganisation;
 
-public class IndexModel(ISupportProjectQueryService supportProjectQueryService,ErrorService errorService, IMediator mediator) : BaseSupportProjectPageModel(supportProjectQueryService,errorService),IDateValidationMessageProvider
+public class IndexModel(ISupportProjectQueryService supportProjectQueryService, ErrorService errorService, IMediator mediator) : BaseSupportProjectPageModel(supportProjectQueryService, errorService), IDateValidationMessageProvider
 {
     [BindProperty(Name = "organisation-name")]
-    public string? OrganisationName  { get; set; }
-    
-    [BindProperty(Name = "id-number")]
-    
-    public string? IdNumber  { get; set; }
-    
-    public bool ShowError { get; set; }
-    
+    public string? OrganisationName { get; set; }
 
-    
+    [BindProperty(Name = "id-number")]
+
+    public string? IdNumber { get; set; }
+
+    public bool ShowError { get; set; }
+
     [BindProperty(Name = "date-support-organisation-chosen", BinderType = typeof(DateInputModelBinder))]
-    [DateValidation(Dfe.ManageSchoolImprovement.Frontend.Services.DateRangeValidationService.DateRange.PastOrToday)]
-    
-    public DateTime? DateSupportOrganisationChosen  { get; set; }
-    
+    [DateValidation(DateRangeValidationService.DateRange.PastOrToday)]
+
+    public DateTime? DateSupportOrganisationChosen { get; set; }
+
+    [BindProperty(Name = "complete-assessment")]
+    public bool CompleteAssessmentTool { get; set; }
+
     string IDateValidationMessageProvider.SomeMissing(string displayName, IEnumerable<string> missingParts)
     {
         return $"Date must include a {string.Join(" and ", missingParts)}";
@@ -35,39 +36,39 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService,E
     {
         return $"Enter the preferred date for supporting organisation chosen";
     }
-    
+
     public async Task<IActionResult> OnGet(int id, CancellationToken cancellationToken)
     {
         await base.GetSupportProject(id, cancellationToken);
-        
+
         OrganisationName = SupportProject.SupportOrganisationName;
         IdNumber = SupportProject.SupportOrganisationIdNumber;
         DateSupportOrganisationChosen = SupportProject.DateSupportOrganisationChosen;
 
         return Page();
     }
-    
-    public async Task<IActionResult> OnPost(int id,CancellationToken cancellationToken)
+
+    public async Task<IActionResult> OnPost(int id, CancellationToken cancellationToken)
     {
-      
-        
+
+
         if (!ModelState.IsValid)
         {
             _errorService.AddErrors(Request.Form.Keys, ModelState);
             ShowError = true;
             return await base.GetSupportProject(id, cancellationToken);
         }
-        
-        var request = new SetChoosePreferredSupportingOrganisationCommand(new SupportProjectId(id),  OrganisationName ,IdNumber,DateSupportOrganisationChosen );
+
+        var request = new SetChoosePreferredSupportingOrganisationCommand(new SupportProjectId(id), OrganisationName, IdNumber, DateSupportOrganisationChosen);
 
         var result = await mediator.Send(request, cancellationToken);
-       
+
         if (result != true)
         {
             _errorService.AddApiError();
             return await base.GetSupportProject(id, cancellationToken);
         }
-        
+
         TaskUpdated = true;
         return RedirectToPage(@Links.TaskList.Index.Page, new { id });
     }

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ChoosePreferredSupportingOrganisation/index.cshtml.cs
@@ -24,8 +24,8 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
 
     public DateTime? DateSupportOrganisationChosen { get; set; }
 
-    [BindProperty(Name = "complete-assessment")]
-    public bool CompleteAssessmentTool { get; set; }
+    [BindProperty(Name = "complete-assessment-tool")]
+    public bool? CompleteAssessmentTool { get; set; }
 
     string IDateValidationMessageProvider.SomeMissing(string displayName, IEnumerable<string> missingParts)
     {
@@ -44,7 +44,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
         OrganisationName = SupportProject.SupportOrganisationName;
         IdNumber = SupportProject.SupportOrganisationIdNumber;
         DateSupportOrganisationChosen = SupportProject.DateSupportOrganisationChosen;
-
+        CompleteAssessmentTool = SupportProject.AssessmentToolTwoCompleted;
         return Page();
     }
 
@@ -59,7 +59,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
             return await base.GetSupportProject(id, cancellationToken);
         }
 
-        var request = new SetChoosePreferredSupportingOrganisationCommand(new SupportProjectId(id), OrganisationName, IdNumber, DateSupportOrganisationChosen);
+        var request = new SetChoosePreferredSupportingOrganisationCommand(new SupportProjectId(id), OrganisationName, IdNumber, DateSupportOrganisationChosen, CompleteAssessmentTool);
 
         var result = await mediator.Send(request, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
@@ -164,14 +164,16 @@ public static class TaskStatusViewModel
     {
         if (supportProject.DateSupportOrganisationChosen.HasValue
             && supportProject.SupportOrganisationName != null
-            && !string.IsNullOrWhiteSpace(supportProject.SupportOrganisationIdNumber))
+            && !string.IsNullOrWhiteSpace(supportProject.SupportOrganisationIdNumber)
+            && supportProject.AssessmentToolTwoCompleted == true)
         {
             return TaskListStatus.Complete;
         }
 
         if (!supportProject.DateSupportOrganisationChosen.HasValue
             && supportProject.SupportOrganisationName == null
-            && string.IsNullOrWhiteSpace(supportProject.SupportOrganisationIdNumber))
+            && string.IsNullOrWhiteSpace(supportProject.SupportOrganisationIdNumber)
+            && supportProject.AssessmentToolTwoCompleted == null)
         {
             return TaskListStatus.NotStarted;
         }

--- a/src/Dfe.ManageSchoolImprovement/appsettings.json
+++ b/src/Dfe.ManageSchoolImprovement/appsettings.json
@@ -39,5 +39,7 @@
   "PreviousFundingChecksSpreadsheetLink": "PreviousFundingChecksSpreadsheetLink",
   "CoastingNotificationLetterLink": "#",
   "NoticeToEnterIntoArrangementsLink": "#",
-  "TerminationWarningNoticeLink": "#"
+  "TerminationWarningNoticeLink": "#",
+  "AssessmentToolTwoLink": "#",
+  "AssessmentToolTwoSharePointFolderLink":  "#"
 }

--- a/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetChoosePreferredSupportingOrganisationTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetChoosePreferredSupportingOrganisationTests.cs
@@ -1,8 +1,8 @@
-using System.Linq.Expressions;
 using AutoFixture;
 using Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.UpdateSupportProject;
 using Dfe.ManageSchoolImprovement.Domain.Interfaces.Repositories;
 using Moq;
+using System.Linq.Expressions;
 
 namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportProject.UpdateSupportProject;
 
@@ -29,7 +29,8 @@ public class SetChoosePreferredSupportingOrganisationTests
             _mockSupportProject.Id,
             "Org",
             "1223a",
-            DateTime.Now
+            DateTime.Now,
+            true
         );
         _mockSupportProjectRepository.Setup(repo => repo.FindAsync(It.IsAny<Expression<Func<Domain.Entities.SupportProject.SupportProject, bool>>>(), It.IsAny<CancellationToken>())).ReturnsAsync(_mockSupportProject);
         var setChosePreferredSupportingOrganisationHandler = new SetChoosePreferredSupportingOrganisation.SetChoosePreferredSupportingOrganisationHandler(_mockSupportProjectRepository.Object);
@@ -49,6 +50,7 @@ public class SetChoosePreferredSupportingOrganisationTests
         var command = new SetChoosePreferredSupportingOrganisationCommand(
             _mockSupportProject.Id,
             null,
+           null,
            null,
            null
         );
@@ -71,7 +73,8 @@ public class SetChoosePreferredSupportingOrganisationTests
             _mockSupportProject.Id,
             "Org",
             "1223a",
-            DateTime.Now
+            DateTime.Now,
+            true
         );
         _mockSupportProjectRepository.Setup(repo => repo.FindAsync(It.IsAny<Expression<Func<Domain.Entities.SupportProject.SupportProject, bool>>>(), It.IsAny<CancellationToken>())).ReturnsAsync((Domain.Entities.SupportProject.SupportProject)null);
         var setChosePreferredSupportingOrganisationHandler = new SetChoosePreferredSupportingOrganisation.SetChoosePreferredSupportingOrganisationHandler(_mockSupportProjectRepository.Object);

--- a/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
@@ -300,17 +300,21 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             DateTime? dateSupportOrganisationChosen = DateTime.UtcNow;
             string? supportOrgansiationName = "name";
             string? supportOrganisationId = "1234a";
+            bool? assessmentToolTwoCompleted = true;
 
             // Act
             supportProject.SetChoosePreferredSupportOrganisation(
                 dateSupportOrganisationChosen,
                 supportOrgansiationName,
-                supportOrganisationId);
+                supportOrganisationId,
+                assessmentToolTwoCompleted
+                );
 
             // Assert
             supportProject.DateSupportOrganisationChosen.Should().Be(dateSupportOrganisationChosen);
             supportProject.SupportOrganisationName.Should().Be(supportOrgansiationName);
             supportProject.SupportOrganisationIdNumber.Should().Be(supportOrganisationId);
+            supportProject.AssessmentToolTwoCompleted.Should().Be(assessmentToolTwoCompleted);
             this.mockRepository.VerifyAll();
         }
 
@@ -858,11 +862,11 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             var primaryReason = "this is a reason";
             var escalationDetails = "this is some details";
             var dateOfDecision = DateTime.UtcNow;
-            
+
             // Act
             supportProject.SetEngagementConcernEscalation(
                 confirmStepsTaken, primaryReason, escalationDetails, dateOfDecision);
-            
+
             // Assert
             supportProject.EngagementConcernEscalationConfirmStepsTaken.Should().Be(confirmStepsTaken);
             supportProject.EngagementConcernEscalationPrimaryReason.Should().Be(primaryReason);

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
@@ -221,19 +221,19 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.ViewModels
             Assert.Equal(expectedTaskListStatus, taskListStatus);
         }
 
-        public static readonly TheoryData<DateTime?, string?, string, TaskListStatus> ChoosePreferredSupportingOrganisationTaskListStatusCases = new()
+        public static readonly TheoryData<DateTime?, string?, string, bool?, TaskListStatus> ChoosePreferredSupportingOrganisationTaskListStatusCases = new()
         {
-            { null, null, "", TaskListStatus.NotStarted },
-            { DateTime.Now, "name", "12344f", TaskListStatus.Complete },
-            { DateTime.Now, null, "12345f", TaskListStatus.InProgress }
+            { null, null, "", null, TaskListStatus.NotStarted },
+            { DateTime.Now, "name", "12344f", true, TaskListStatus.Complete },
+            { DateTime.Now, null, "12345f", null, TaskListStatus.InProgress }
         };
 
         [Theory, MemberData(nameof(ChoosePreferredSupportingOrganisationTaskListStatusCases))]
-        public void ChoosePreferredSupportingOrganisationShouldReturnCorrectStatus(DateTime? datePreferredSupportOrganisationChosen, string? supportOrganisationName, string supportOrganisationId, TaskListStatus expectedTaskListStatus)
+        public void ChoosePreferredSupportingOrganisationShouldReturnCorrectStatus(DateTime? datePreferredSupportOrganisationChosen, string? supportOrganisationName, string supportOrganisationId, bool? assessmentToolTwoCompleted, TaskListStatus expectedTaskListStatus)
         {
             // Arrange
             var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(1, DateTime.Now, DateSupportOrganisationChosen: datePreferredSupportOrganisationChosen, SupportOrganisationName: supportOrganisationName,
-                SupportOrganisationIdNumber: supportOrganisationId));
+                SupportOrganisationIdNumber: supportOrganisationId, AssessmentToolTwoCompleted: assessmentToolTwoCompleted));
 
             //Action 
             var taskListStatus = TaskStatusViewModel.ChoosePreferredSupportingOrganisationTaskListStatus(supportProjectModel);


### PR DESCRIPTION
#### PR Classification
New feature to enhance the tracking of assessment tool completion status in the SupportProject domain.

#### PR Summary
This pull request introduces the `AssessmentToolTwoCompleted` property across various components of the application, improving the functionality and data model related to supporting organizations. 
- `SetChoosePreferredSupportingOrganisation.cs`: Added `AssessmentToolTwoCompleted` to the command and updated the command handler.
- `SupportProject.cs`: Updated the class to include the new property and modified related methods.
- `SupportProjectDto.cs`: Added the new property to the data transfer object.
- `20250619134200_assessment-tool-two-completed.cs`: Created a migration to add the new column to the database.
- `SupportProjectViewModel.cs`: Updated the view model to bind to the new property for the user interface.
