### PR TITLE
Added tests for About the school and Ofsted report

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/aboutTheSchool.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/aboutTheSchool.cy.ts
@@ -1,0 +1,32 @@
+import aboutTheSchool from "cypress/pages/aboutTheSchool";
+import notes from "cypress/pages/aboutTheSchool";
+import homePage from "cypress/pages/homePage";
+import taskList from "cypress/pages/taskList";
+
+describe("User navigates to About the school tab", () => {
+    const noteText = "This is a test note.";
+    const updatedNoteText = "This is an updated test note.";
+
+    beforeEach(() => {
+        cy.login();
+        homePage
+            .selectFirstSchoolFromList()
+        taskList
+            .navigateToTab('About the school')
+
+        cy.executeAccessibilityTests()
+    });
+
+    it("should see the School overview section", () => {
+        aboutTheSchool.hasSchoolOverviewSection()
+        aboutTheSchool.checkAllFieldsNotEmpty();
+
+        cy.executeAccessibilityTests()
+    });
+
+    it("should expand the information link", () => {
+        aboutTheSchool.expandSectionAndCheckText();
+
+        cy.executeAccessibilityTests()
+    });
+});

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/aboutTheSchool.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/aboutTheSchool.cy.ts
@@ -1,12 +1,8 @@
 import aboutTheSchool from "cypress/pages/aboutTheSchool";
-import notes from "cypress/pages/aboutTheSchool";
 import homePage from "cypress/pages/homePage";
 import taskList from "cypress/pages/taskList";
 
 describe("User navigates to About the school tab", () => {
-    const noteText = "This is a test note.";
-    const updatedNoteText = "This is an updated test note.";
-
     beforeEach(() => {
         cy.login();
         homePage

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/addNotes.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/addNotes.cy.ts
@@ -20,11 +20,18 @@ describe("User navigates to the Notes Tab", () => {
     it("should add a new note", () => {
         notes.clickAddNote();
         notes.enterNote(noteText);
+
+        cy.executeAccessibilityTests()
+
         notes.saveNote();
         notes.hasSuccessNotification();
+
+        cy.executeAccessibilityTests()
     });
 
     it("should edit the first note", () => {
         notes.editFirstNote(updatedNoteText);
+
+        cy.executeAccessibilityTests()
     });
 });

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/ofstedReports.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/ofstedReports.cy.ts
@@ -15,6 +15,7 @@ describe("User navigates to the Ofsted Reports Page", () => {
     });
 
     it.only("should display all the fields in the Most recent and Previous Ofsted report section", () => {
+        Logger.log("check most recent and previous ofsted report section");
         ofstedReports.hasMostRecentOfstedReportSection()
         ofstedReports.hasPreviousOfstedReportSection()
         ofstedReports.checkAllFieldsNotEmpty();
@@ -23,6 +24,7 @@ describe("User navigates to the Ofsted Reports Page", () => {
     });
 
       it("should expand the information link", () => {
+        Logger.log("check that information link expands");
         ofstedReports.expandSectionAndCheckText();
 
         cy.executeAccessibilityTests()

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/ofstedReports.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/ofstedReports.cy.ts
@@ -1,0 +1,31 @@
+import ofstedReports from "cypress/pages/ofstedReports";
+import homePage from "cypress/pages/homePage";
+import taskList from "cypress/pages/taskList";
+import { Logger } from "cypress/common/logger";
+
+describe("User navigates to the Ofsted Reports Page", () => {
+    beforeEach(() => {
+        cy.login();
+        homePage
+            .selectFirstSchoolFromList()
+        taskList
+            .navigateToTab('Ofsted reports')
+
+        cy.executeAccessibilityTests()
+    });
+
+    it.only("should display all the fields in the Most recent and Previous Ofsted report section", () => {
+        ofstedReports.hasMostRecentOfstedReportSection()
+        ofstedReports.hasPreviousOfstedReportSection()
+        ofstedReports.checkAllFieldsNotEmpty();
+
+        cy.executeAccessibilityTests()
+    });
+
+      it("should expand the information link", () => {
+        ofstedReports.expandSectionAndCheckText();
+
+        cy.executeAccessibilityTests()
+    });
+
+});

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/aboutTheSchool.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/aboutTheSchool.ts
@@ -1,8 +1,55 @@
 class AboutTheSchool {
 
   public schoolOverivewSectionVisible(): this {
-        cy.url().should('include', '/about-the-school');
+    cy.url().should('include', '/about-the-school');
     cy.contains('Page not found').should('not.exist');
+
+    return this;
+  }
+
+  public hasSchoolOverviewSection(): this {
+    cy.get('h2').should('contain', 'School overview');
+
+    return this;
+  }
+  public checkAllFieldsNotEmpty(): this {
+    const expectedFields = [
+      'Previous URN',
+      'Region',
+      'Local authority',
+      'School type',
+      'School phase',
+      'Religious character',
+      'Diocese',
+      'Number on roll (NOR)'
+    ];
+
+    expectedFields.forEach(fieldName => {
+      cy.get('dl.govuk-summary-list')
+        .find('dt.govuk-summary-list__key')
+        .contains(fieldName)
+        .closest('.govuk-summary-list__row')
+        .find('dd.govuk-summary-list__value')
+        .should('exist')
+        .and('not.be.empty');
+    });
+
+    cy.get('.govuk-summary-card__content').within(() => {
+      cy.get('dd.govuk-summary-list__value').each($el => {
+        cy.wrap($el)
+          .should('exist')
+          .and('not.be.empty');
+      });
+    });
+    
+    return this;
+  }
+
+  public expandSectionAndCheckText(): this {
+    cy.get('.govuk-details').click();
+    cy.get('.govuk-details__text')
+      .should('be.visible')
+      .and('not.be.empty');
 
     return this;
   }

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/ofstedReports.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/ofstedReports.ts
@@ -1,6 +1,4 @@
 class OfstedReports {
-
-
     public hasOfstedReport(value: string): this {
         cy.get('h2').should("be.visible");
 

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/ofstedReports.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/ofstedReports.ts
@@ -14,6 +14,65 @@ class OfstedReports {
         return this;
     }
 
+    public hasMostRecentOfstedReportSection(): this {
+        cy.get('h2').contains('Most recent Ofsted report')
+            .should('be.visible');
+
+        return this;
+    }
+
+    public hasPreviousOfstedReportSection(): this {
+        cy.get('h2').contains('Previous Ofsted report')
+            .should('be.visible');
+
+        return this;
+    }
+
+    public checkAllFieldsNotEmpty(): this {
+        const expectedFields = [
+            'Date of last inspection',
+            'Quality of education',
+            'Behaviour and attitudes',
+            'Personal development',
+            'Leadership and management',
+            'Date of last inspection',
+            'Quality of education',
+            'Behaviour and attitudes',
+            'Personal development',
+            'Leadership and management',
+        ];
+
+        expectedFields.forEach(fieldName => {
+            cy.get('dl.govuk-summary-list')
+                .find('dt.govuk-summary-list__key')
+                .contains(fieldName)
+                .closest('.govuk-summary-list__row')
+                .find('dd.govuk-summary-list__value')
+                .should('exist')
+                .and('not.be.empty');
+        });
+
+        cy.get('.govuk-summary-card__content').each(($el, index) => {
+            cy.wrap($el).within(() => {
+                cy.get('dd.govuk-summary-list__value').each($el => {
+                    cy.wrap($el)
+                        .should('exist')
+                        .and('not.be.empty');
+                });
+            });
+        })
+        return this;
+    }
+
+    public expandSectionAndCheckText(): this {
+        cy.get('.govuk-details').click();
+        cy.get('.govuk-details__text')
+            .should('be.visible')
+            .and('not.be.empty');
+
+        return this;
+    }
+
 }
 
 const ofstedReports = new OfstedReports();


### PR DESCRIPTION
This PR covers the tests for
 1. About the school tab
     verifying the fields
     verifying the link
    
2. Ofsted Report
    verifying the Most recent Ofsted report
    verifying the Previous Ofsted report
    verifying the link
    
Also updated Add Notes test for accessibility