### PR TITLE
Changes to matching decision page

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetRecordMatchingDecision.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetRecordMatchingDecision.cs
@@ -7,8 +7,8 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.Update
     public record SetRecordMatchingDecisionCommand(
         SupportProjectId SupportProjectId,
         DateTime? RegionalDirectorDecisionDate,
-        bool? HasSchoolMatchedWithSupportingOrganisation,
-        string? NotMatchingSchoolWithSupportingOrgNotes
+        string? InitialDiagnosisMatchingDecision,
+        string? InitialDiagnosisMatchingDecisionNotes
     ) : IRequest<bool>;
 
     public class SetRecordMatchingDecisionCommandHandler(ISupportProjectRepository supportProjectRepository)
@@ -24,7 +24,7 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.Update
                 return false;
             }
 
-            supportProject.SetRecordMatchingDecision(request.RegionalDirectorDecisionDate, request.HasSchoolMatchedWithSupportingOrganisation, request.NotMatchingSchoolWithSupportingOrgNotes);
+            supportProject.SetRecordMatchingDecision(request.RegionalDirectorDecisionDate, request.InitialDiagnosisMatchingDecision, request.InitialDiagnosisMatchingDecisionNotes);
 
             await supportProjectRepository.UpdateAsync(supportProject, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetRecordMatchingDecision.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Commands/UpdateSupportProject/SetRecordMatchingDecision.cs
@@ -4,7 +4,7 @@ using MediatR;
 
 namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.UpdateSupportProject
 {
-    public record SetRecordMatchingDecisionCommand(
+    public record SetRecordInitialDiagnosisDecisionCommand(
         SupportProjectId SupportProjectId,
         DateTime? RegionalDirectorDecisionDate,
         string? InitialDiagnosisMatchingDecision,
@@ -12,9 +12,9 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.Update
     ) : IRequest<bool>;
 
     public class SetRecordMatchingDecisionCommandHandler(ISupportProjectRepository supportProjectRepository)
-        : IRequestHandler<SetRecordMatchingDecisionCommand, bool>
+        : IRequestHandler<SetRecordInitialDiagnosisDecisionCommand, bool>
     {
-        public async Task<bool> Handle(SetRecordMatchingDecisionCommand request,
+        public async Task<bool> Handle(SetRecordInitialDiagnosisDecisionCommand request,
             CancellationToken cancellationToken)
         {
             var supportProject = await supportProjectRepository.FindAsync(x => x.Id == request.SupportProjectId, cancellationToken);
@@ -24,7 +24,7 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Commands.Update
                 return false;
             }
 
-            supportProject.SetRecordMatchingDecision(request.RegionalDirectorDecisionDate, request.InitialDiagnosisMatchingDecision, request.InitialDiagnosisMatchingDecisionNotes);
+            supportProject.SetRecordInitialDiagnosisMatchingDecision(request.RegionalDirectorDecisionDate, request.InitialDiagnosisMatchingDecision, request.InitialDiagnosisMatchingDecisionNotes);
 
             await supportProjectRepository.UpdateAsync(supportProject, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
+++ b/src/Dfe.ManageSchoolImprovement.Application/SupportProject/Models/SupportProjectDto.cs
@@ -38,6 +38,8 @@ namespace Dfe.ManageSchoolImprovement.Application.SupportProject.Models
         DateTime? RegionalDirectorDecisionDate = null,
         bool? HasSchoolMatchedWithSupportingOrganisation = null,
         string? NotMatchingSchoolWithSupportingOrgNotes = null,
+        string? InitialDiagnosisMatchingDecision = null,
+        string? InitialDiagnosisMatchingDecisionNotes = null,
         bool? CheckOrganisationHasCapacityAndWillingToProvideSupport = null,
         bool? CheckChoiceWithTrustRelationshipManagerOrLaLead = null,
         bool? DiscussChoiceWithSfso = null,

--- a/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
+++ b/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
@@ -312,7 +312,7 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
         AssessmentToolTwoCompleted = assessmentToolTwoCompleted;
     }
 
-    public void SetRecordMatchingDecision(DateTime? regionalDirectorDecisionDate, string? initialDiagnosisMatchingDecision, string? initialDiagnosisMatchingDecisionNotes)
+    public void SetRecordInitialDiagnosisMatchingDecision(DateTime? regionalDirectorDecisionDate, string? initialDiagnosisMatchingDecision, string? initialDiagnosisMatchingDecisionNotes)
     {
         RegionalDirectorDecisionDate = regionalDirectorDecisionDate;
         InitialDiagnosisMatchingDecision = initialDiagnosisMatchingDecision;

--- a/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
+++ b/src/Dfe.ManageSchoolImprovement.Domain/Entities/SupportProject/SupportProject.cs
@@ -101,9 +101,8 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
     public bool? AssessmentToolTwoCompleted { get; private set; }
     public DateTime? RegionalDirectorDecisionDate { get; private set; }
 
-    public bool? HasSchoolMatchedWithSupportingOrganisation { get; private set; }
-
-    public string? NotMatchingSchoolWithSupportingOrgNotes { get; private set; }
+    public string? InitialDiagnosisMatchingDecision { get; private set; }
+    public string? InitialDiagnosisMatchingDecisionNotes { get; private set; }
 
     public DateTime? DateSupportingOrganisationContactDetailsAdded { get; private set; }
 
@@ -313,11 +312,11 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
         AssessmentToolTwoCompleted = assessmentToolTwoCompleted;
     }
 
-    public void SetRecordMatchingDecision(DateTime? regionalDirectorDecisionDate, bool? hasSchoolMatchedWithSupportingOrganisation, string? notMatchingSchoolWithSupportingOrgNotes)
+    public void SetRecordMatchingDecision(DateTime? regionalDirectorDecisionDate, string? initialDiagnosisMatchingDecision, string? initialDiagnosisMatchingDecisionNotes)
     {
         RegionalDirectorDecisionDate = regionalDirectorDecisionDate;
-        HasSchoolMatchedWithSupportingOrganisation = hasSchoolMatchedWithSupportingOrganisation;
-        NotMatchingSchoolWithSupportingOrgNotes = notMatchingSchoolWithSupportingOrgNotes;
+        InitialDiagnosisMatchingDecision = initialDiagnosisMatchingDecision;
+        InitialDiagnosisMatchingDecisionNotes = initialDiagnosisMatchingDecisionNotes;
     }
 
     public void SetSupportingOrganisationContactDetails(DateTime? dateSupportingOrganisationContactDetailsAdded, string? supportingOrganisationContactName, string? supportingOrganisationContactEmailAddress)
@@ -383,8 +382,8 @@ public class SupportProject : BaseAggregateRoot, IEntity<SupportProjectId>
         SendRequestingPlanningGrantOfferEmailToRiseGrantTeam = emailRiseGrantTeam;
     }
 
-    public void SetReviewTheImprovementPlan(DateTime? improvementPlanReceivedDate, 
-        bool? reviewImprovementAndExpenditurePlan, 
+    public void SetReviewTheImprovementPlan(DateTime? improvementPlanReceivedDate,
+        bool? reviewImprovementAndExpenditurePlan,
         bool? confirmFundingBand,
         string? fundingBand,
         bool? confirmPlanClearedByRiseGrantTeam)

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250714142438_initial-diagnosis-matching-decision.Designer.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250714142438_initial-diagnosis-matching-decision.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageSchoolImprovement.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
 {
     [DbContext(typeof(RegionalImprovementForStandardsAndExcellenceContext))]
-    partial class RegionalImprovementForStandardsAndExcellenceContextModelSnapshot : ModelSnapshot
+    [Migration("20250714142438_initial-diagnosis-matching-decision")]
+    partial class initialdiagnosismatchingdecision
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250714142438_initial-diagnosis-matching-decision.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250714142438_initial-diagnosis-matching-decision.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class initialdiagnosismatchingdecision : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InitialDiagnosisMatchingDecision",
+                schema: "RISE",
+                table: "SupportProject",
+                type: "nvarchar(max)",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.AddColumn<string>(
+                name: "InitialDiagnosisMatchingDecisionNotes",
+                schema: "RISE",
+                table: "SupportProject",
+                type: "nvarchar(max)",
+                nullable: true)
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+
+            // Migrate data from old column boolean values to new column string values
+            migrationBuilder.Sql(@"
+                UPDATE RISE.SupportProject
+                SET InitialDiagnosisMatchingDecision = CASE 
+                    WHEN HasSchoolMatchedWithSupportingOrganisation = 1 THEN 'matchWithOrganisation'
+                    WHEN HasSchoolMatchedWithSupportingOrganisation = 0 THEN 'reviewSchoolProgress'
+                    ELSE NULL
+                END
+            ");
+
+            // Migrate Notes
+            migrationBuilder.Sql(@"
+                UPDATE RISE.SupportProject
+                SET InitialDiagnosisMatchingDecisionNotes = NotMatchingSchoolWithSupportingOrgNotes
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InitialDiagnosisMatchingDecision",
+                schema: "RISE",
+                table: "SupportProject")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+
+            migrationBuilder.DropColumn(
+                name: "InitialDiagnosisMatchingDecisionNotes",
+                schema: "RISE",
+                table: "SupportProject")
+                .Annotation("SqlServer:IsTemporal", true)
+                .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
+                .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
+                .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
+                .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
+        }
+    }
+}

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250715100711_remove-old-matching-decision-fields.Designer.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250715100711_remove-old-matching-decision-fields.Designer.cs
@@ -4,6 +4,7 @@ using Dfe.ManageSchoolImprovement.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
 {
     [DbContext(typeof(RegionalImprovementForStandardsAndExcellenceContext))]
-    partial class RegionalImprovementForStandardsAndExcellenceContextModelSnapshot : ModelSnapshot
+    [Migration("20250715100711_remove-old-matching-decision-fields")]
+    partial class removeoldmatchingdecisionfields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250715100711_remove-old-matching-decision-fields.cs
+++ b/src/Dfe.ManageSchoolImprovement.Infrastructure/Migrations/20250715100711_remove-old-matching-decision-fields.cs
@@ -5,70 +5,53 @@
 namespace Dfe.ManageSchoolImprovement.Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class initialdiagnosismatchingdecision : Migration
+    public partial class removeoldmatchingdecisionfields : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "InitialDiagnosisMatchingDecision",
+            migrationBuilder.DropColumn(
+                name: "HasSchoolMatchedWithSupportingOrganisation",
                 schema: "RISE",
-                table: "SupportProject",
-                type: "nvarchar(max)",
-                nullable: true)
+                table: "SupportProject")
                 .Annotation("SqlServer:IsTemporal", true)
                 .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
                 .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
                 .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
                 .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
 
-            migrationBuilder.AddColumn<string>(
-                name: "InitialDiagnosisMatchingDecisionNotes",
+            migrationBuilder.DropColumn(
+                name: "NotMatchingSchoolWithSupportingOrgNotes",
                 schema: "RISE",
-                table: "SupportProject",
-                type: "nvarchar(max)",
-                nullable: true)
+                table: "SupportProject")
                 .Annotation("SqlServer:IsTemporal", true)
                 .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
                 .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
                 .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
                 .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
-
-
-            // Migrate data from old column boolean values to new column string values
-            migrationBuilder.Sql(@"
-                UPDATE RISE.SupportProject
-                SET InitialDiagnosisMatchingDecision = CASE 
-                    WHEN HasSchoolMatchedWithSupportingOrganisation = 1 THEN 'Match with a supporting organisation'
-                    WHEN HasSchoolMatchedWithSupportingOrganisation = 0 THEN 'Review school''s progress'
-                    ELSE NULL
-                END
-            ");
-
-            // Migrate Notes
-            migrationBuilder.Sql(@"
-                UPDATE RISE.SupportProject
-                SET InitialDiagnosisMatchingDecisionNotes = NotMatchingSchoolWithSupportingOrgNotes
-            ");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "InitialDiagnosisMatchingDecision",
+            migrationBuilder.AddColumn<bool>(
+                name: "HasSchoolMatchedWithSupportingOrganisation",
                 schema: "RISE",
-                table: "SupportProject")
+                table: "SupportProject",
+                type: "bit",
+                nullable: true)
                 .Annotation("SqlServer:IsTemporal", true)
                 .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
                 .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")
                 .Annotation("SqlServer:TemporalPeriodEndColumnName", "PeriodEnd")
                 .Annotation("SqlServer:TemporalPeriodStartColumnName", "PeriodStart");
 
-            migrationBuilder.DropColumn(
-                name: "InitialDiagnosisMatchingDecisionNotes",
+            migrationBuilder.AddColumn<string>(
+                name: "NotMatchingSchoolWithSupportingOrgNotes",
                 schema: "RISE",
-                table: "SupportProject")
+                table: "SupportProject",
+                type: "nvarchar(max)",
+                nullable: true)
                 .Annotation("SqlServer:IsTemporal", true)
                 .Annotation("SqlServer:TemporalHistoryTableName", "SupportProjectHistory")
                 .Annotation("SqlServer:TemporalHistoryTableSchema", "RISE")

--- a/src/Dfe.ManageSchoolImprovement/Models/Links.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/Links.cs
@@ -66,7 +66,7 @@ public static class Links
         public static readonly LinkItem CompleteAndSaveInitialDiagnosisAssessment = AddLinkItem(backText: "Back", page: "/TaskList/CompleteAndSaveInitialDiagnosisAssessment/Index");
         public static readonly LinkItem RecordVisitDateToVisitSchool = AddLinkItem(backText: "Back", page: "/TaskList/RecordVisitDateToVisitSchool/Index");
         public static readonly LinkItem ChoosePreferredSupportingOrganisation = AddLinkItem(backText: "Back", page: "/TaskList/ChoosePreferredSupportingOrganisation/Index");
-        public static readonly LinkItem RecordMatchingDecision = AddLinkItem(backText: "Back", page: "/TaskList/RecordMatchingDecision/Index");
+        public static readonly LinkItem RecordInitialDiagnosisDecision = AddLinkItem(backText: "Back", page: "/TaskList/RecordInitialDiagnosisDecision/Index");
         public static readonly LinkItem AddSupportingOrganisationContactDetails = AddLinkItem(backText: "Back", page: "/TaskList/AddSupportingOrganisationContactDetails/Index");
         public static readonly LinkItem DueDiligenceOnPreferredSupportingOrganisation = AddLinkItem(backText: "Back", page: "/TaskList/DueDiligenceOnPreferredSupportingOrganisation/Index");
         public static readonly LinkItem RecordSupportingOrganisationAppointment = AddLinkItem(backText: "Back", page: "/TaskList/RecordSupportingOrganisationAppointment/Index");

--- a/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/SupportProject/SupportProjectViewModel.cs
@@ -89,6 +89,8 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
         public bool? HasSchoolMatchedWithSupportingOrganisation { get; set; }
         public DateTime? RegionalDirectorDecisionDate { get; set; }
         public string? NotMatchingSchoolWithSupportingOrgNotes { get; set; }
+        public string? InitialDiagnosisMatchingDecision { get; set; }
+        public string? InitialDiagnosisMatchingDecisionNotes { get; set; }
 
         public DateTime? DateSupportOrganisationChosen { get; set; }
 
@@ -217,6 +219,8 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Models.SupportProject
                 RegionalDirectorDecisionDate = supportProjectDto.RegionalDirectorDecisionDate,
                 HasSchoolMatchedWithSupportingOrganisation = supportProjectDto.HasSchoolMatchedWithSupportingOrganisation,
                 NotMatchingSchoolWithSupportingOrgNotes = supportProjectDto.NotMatchingSchoolWithSupportingOrgNotes,
+                InitialDiagnosisMatchingDecision = supportProjectDto.InitialDiagnosisMatchingDecision,
+                InitialDiagnosisMatchingDecisionNotes = supportProjectDto.InitialDiagnosisMatchingDecisionNotes,
                 CheckOrganisationHasCapacityAndWillingToProvideSupport = supportProjectDto.CheckOrganisationHasCapacityAndWillingToProvideSupport,
                 CheckChoiceWithTrustRelationshipManagerOrLaLead = supportProjectDto.CheckChoiceWithTrustRelationshipManagerOrLaLead,
                 DiscussChoiceWithSfso = supportProjectDto.DiscussChoiceWithSfso,

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -162,8 +162,8 @@
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        <a class="govuk-link govuk-task-list__link" asp-page="@Links.TaskList.RecordMatchingDecision.Page" asp-route-id="@Model.SupportProject.Id" data-cy="record-support-decision" aria-describedby="record-support-decision_status">
-                            Record matching decision
+                        <a class="govuk-link govuk-task-list__link" asp-page="@Links.TaskList.RecordInitialDiagnosisDecision.Page" asp-route-id="@Model.SupportProject.Id" data-cy="record-support-decision" aria-describedby="record-support-decision_status">
+                            Record initial diagnosis decision
                         </a>
                     </div>
                     <div class="govuk-task-list__status" id="record-support-decision_status">

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
@@ -64,7 +64,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
         RecordVisitDateToVisitSchoolTaskListStatus = TaskStatusViewModel.RecordVisitDateToVisitSchoolTaskListStatus(SupportProject);
         ChosePreferredSupportingOrganisationTaskListStatus =
             TaskStatusViewModel.ChoosePreferredSupportingOrganisationTaskListStatus(SupportProject);
-        RecordSupportDecisionTaskListStatus = TaskStatusViewModel.RecordSupportDecisionTaskListStatus(SupportProject);
+        RecordSupportDecisionTaskListStatus = TaskStatusViewModel.RecordInitialDiagnosisDecisionTaskListStatus(SupportProject);
         DueDiligenceOnPreferredSupportingOrganisationTaskListStatus = TaskStatusViewModel.DueDiligenceOnPreferredSupportingOrganisationTaskListStatus(SupportProject);
         SetRecordSupportingOrganisationAppointment = TaskStatusViewModel.SetRecordSupportingOrganisationAppointmentTaskListStatus(SupportProject);
         SupportingOrganisationContactDetailsTaskListStatus =

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml
@@ -1,4 +1,4 @@
-@page "/task-list/record-matching-decision/{id:int}"
+@page "/task-list/record-initial-diagnosis-decision/{id:int}"
 @model Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDecision.IndexModel
 @inject IConfiguration Configuration
 @{

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
@@ -20,8 +20,6 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
         [BindProperty(Name = "HasSchoolMatchedWithSupportingOrganisation")]
         public string? HasSchoolMatchedWithSupportingOrganisation { get; set; }
 
-
-
         [BindProperty(Name = "NotMatchingNotes")]
         public string? NotMatchingNotes { get; set; }
 
@@ -53,11 +51,11 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
             RegionalDirectorDecisionDate = SupportProject.RegionalDirectorDecisionDate;
 
             // Populate the appropriate notes property based on the decision
-            if (HasSchoolMatchedWithSupportingOrganisation == "reviewSchoolProgress")
+            if (HasSchoolMatchedWithSupportingOrganisation == "Review school's progress")
             {
                 NotMatchingNotes = SupportProject.InitialDiagnosisMatchingDecisionNotes;
             }
-            else if (HasSchoolMatchedWithSupportingOrganisation == "unableToAssess")
+            else if (HasSchoolMatchedWithSupportingOrganisation == "Unable to assess")
             {
                 UnableToAssessNotes = SupportProject.InitialDiagnosisMatchingDecisionNotes;
             }
@@ -65,6 +63,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
             RadioButtonModels = RadioButtons;
             return Page();
         }
+        
         public async Task<IActionResult> OnPost(int id, CancellationToken cancellationToken)
         {
             bool hasValidationErrors = false;
@@ -97,8 +96,8 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
             // Determine which notes to pass to the command based on the selection
             string? notesToPass = HasSchoolMatchedWithSupportingOrganisation switch
             {
-                "reviewSchoolProgress" => NotMatchingNotes,
-                "unableToAssess" => UnableToAssessNotes,
+                "Review school's progress" => NotMatchingNotes,
+                "Unable to assess" => UnableToAssessNotes,
                 _ => null
             };
 
@@ -115,7 +114,6 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
             TaskUpdated = true;
             return RedirectToPage(@Links.TaskList.Index.Page, new { id });
         }
-
 
         private IList<RadioButtonsLabelViewModel> RadioButtons
         {
@@ -164,7 +162,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
 
         private bool IsNotMatchingNotesValid()
         {
-            if (HasSchoolMatchedWithSupportingOrganisation == "reviewSchoolProgress" && string.IsNullOrWhiteSpace(NotMatchingNotes))
+            if (HasSchoolMatchedWithSupportingOrganisation == "Review school's progress" && string.IsNullOrWhiteSpace(NotMatchingNotes))
             {
                 return false;
             }
@@ -173,7 +171,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
 
         private bool IsUnableToAssessNotesValid()
         {
-            if (HasSchoolMatchedWithSupportingOrganisation == "unableToAssess" && string.IsNullOrWhiteSpace(UnableToAssessNotes))
+            if (HasSchoolMatchedWithSupportingOrganisation == "Unable to assess" && string.IsNullOrWhiteSpace(UnableToAssessNotes))
             {
                 return false;
             }

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
@@ -63,7 +63,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
             RadioButtonModels = RadioButtons;
             return Page();
         }
-        
+
         public async Task<IActionResult> OnPost(int id, CancellationToken cancellationToken)
         {
             bool hasValidationErrors = false;
@@ -101,7 +101,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDeci
                 _ => null
             };
 
-            var request = new SetRecordMatchingDecisionCommand(new SupportProjectId(id), RegionalDirectorDecisionDate, HasSchoolMatchedWithSupportingOrganisation, notesToPass);
+            var request = new SetRecordInitialDiagnosisDecisionCommand(new SupportProjectId(id), RegionalDirectorDecisionDate, HasSchoolMatchedWithSupportingOrganisation, notesToPass);
 
             var result = await mediator.Send(request, cancellationToken);
 

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordMatchingDecision/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordMatchingDecision/Index.cshtml
@@ -1,7 +1,8 @@
 @page "/task-list/record-matching-decision/{id:int}"
 @model Dfe.ManageSchoolImprovement.Frontend.Pages.TaskList.RecordMatchingDecision.IndexModel
+@inject IConfiguration Configuration
 @{
-    ViewData["Title"] = "Record matching decision";
+    ViewData["Title"] = "Record initial diagnosis decision";
 }
 
 @section BeforeMain
@@ -11,23 +12,39 @@
 
 @if (Model.ShowError)
 {
-   <partial name="_ErrorSummary"/>
+    <partial name="_ErrorSummary" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l" data-cy="school-name">@Model.SupportProject.SchoolName</span>
         <h1 class="govuk-heading-l" data-cy="page-heading">
-            Record matching decision
+            Record initial diagnosis decision
         </h1>
+
+        <p class="govuk-body">Using <a href="@Configuration["AssessmentToolOneLink"]" class="govuk-link" target="_blank">Assessment Tool 1: Initial Diagnosis (opens in new tab)</a>, confirm if this school will be matched with a supporting organisation or not. A regional director must have approved this decision.</p>
+
         <form method="post" novalidate>
-            <p class="govuk-body" data-cy="confirm-matching-with-hqo">Confirm whether this school will be matched with a supporting organisation. A regional director must have approved this decision.</p>
-            <govuk-radiobuttons-input heading="Record decision" heading-style="govuk-fieldset__legend--m" hint="If the school will not be matched with a supporting organisation, add details to explain why."
-                                      name="@nameof(Model.HasSchoolMatchedWithSupportingOrganisation)" radio-buttons="@Model.RadioButtoons" asp-for="@Model.HasSchoolMatchedWithSupportingOrganisation" />
-            <govuk-date-input heading-label="false" label="Enter date the regional director made this decision" id="decision-date" name="decision-date" asp-for="@Model.RegionalDirectorDecisionDate" hint="For example, 1 7 2024." />
+            <govuk-radiobuttons-input heading="Record decision" 
+                                      heading-style="govuk-fieldset__legend govuk-fieldset__legend--m"
+                                      hint="Enter the reasons for the decision if the school could not be assessed."
+                                      name="@nameof(Model.HasSchoolMatchedWithSupportingOrganisation)"
+                                      asp-for="@Model.HasSchoolMatchedWithSupportingOrganisation"
+                                      radio-buttons="@Model.RadioButtonModels"
+                                      has-error="@Model.ShowError"
+                                      error-message="@Model.ErrorMessage" />
+
+            <govuk-date-input heading-label="false"
+                              label="Enter date the regional director made this decision"
+                              id="decision-date"
+                              name="decision-date"
+                              asp-for="@Model.RegionalDirectorDecisionDate"
+                              hint="For example, 1 7 2024." />
+
             <button class="govuk-button" type="submit" id="save-and-continue-button" data-module="govuk-button" data-cy="select-common-submitbutton">
                 Save and return
             </button>
         </form>
     </div>
 </div>
+

--- a/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
@@ -169,17 +169,16 @@ public static class TaskStatusViewModel
         return TaskListStatus.InProgress;
     }
 
-    public static TaskListStatus RecordSupportDecisionTaskListStatus(SupportProjectViewModel supportProject)
+    public static TaskListStatus RecordInitialDiagnosisDecisionTaskListStatus(SupportProjectViewModel supportProject)
     {
         if (supportProject.RegionalDirectorDecisionDate.HasValue
-            && supportProject.HasSchoolMatchedWithSupportingOrganisation.HasValue
-            && supportProject.HasSchoolMatchedWithSupportingOrganisation.Equals(true))
+            && !string.IsNullOrEmpty(supportProject.InitialDiagnosisMatchingDecision))
         {
             return TaskListStatus.Complete;
         }
 
         if (!supportProject.RegionalDirectorDecisionDate.HasValue
-            && !supportProject.HasSchoolMatchedWithSupportingOrganisation.HasValue)
+            && string.IsNullOrEmpty(supportProject.InitialDiagnosisMatchingDecision))
         {
             return TaskListStatus.NotStarted;
         }

--- a/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetRecordMatchingDecisionTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetRecordMatchingDecisionTests.cs
@@ -25,14 +25,14 @@ namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportP
         {
             // Arrange
             var regionalDirectorDecisionDate = DateTime.UtcNow;
-            var hasSchoolMatchedWithSupportingOrganisation = true;
-            var notMatchingSchoolWithSupportingOrgNotes = "Random Notes";
+            var initialDiagnosisMatchingDecision = "Match with a supporting organisation";
+            var initialDiagnosisMatchingDecisionNotes = "Random Notes";
 
             var command = new SetRecordMatchingDecisionCommand(
                 _mockSupportProject.Id,
                 regionalDirectorDecisionDate,
-                hasSchoolMatchedWithSupportingOrganisation,
-                notMatchingSchoolWithSupportingOrgNotes
+                initialDiagnosisMatchingDecision,
+                initialDiagnosisMatchingDecisionNotes
             );
             _mockSupportProjectRepository.Setup(repo => repo.FindAsync(It.IsAny<Expression<Func<Domain.Entities.SupportProject.SupportProject, bool>>>(), It.IsAny<CancellationToken>())).ReturnsAsync(_mockSupportProject);
             var handler = new SetRecordMatchingDecisionCommandHandler(_mockSupportProjectRepository.Object);
@@ -71,14 +71,14 @@ namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportP
         {
             // Arrange
             var regionalDirectorDecisionDate = DateTime.UtcNow;
-            var hasSchoolMatchedWithSupportingOrganisation = true;
-            var notMatchingSchoolWithSupportingOrgNotes = "Random Notes";
+            var initialDiagnosisMatchingDecision = "Match with a supporting organisation";
+            var initialDiagnosisMatchingDecisionNotes = "Random Notes";
 
             var command = new SetRecordMatchingDecisionCommand(
                 _mockSupportProject.Id,
                 regionalDirectorDecisionDate,
-                hasSchoolMatchedWithSupportingOrganisation,
-                notMatchingSchoolWithSupportingOrgNotes
+                initialDiagnosisMatchingDecision,
+                initialDiagnosisMatchingDecisionNotes
             );
 
             _mockSupportProjectRepository.Setup(repo => 

--- a/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetRecordMatchingDecisionTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Application.Tests/CommandHandlers/SupportProject/UpdateSupportProject/SetRecordMatchingDecisionTests.cs
@@ -28,7 +28,7 @@ namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportP
             var initialDiagnosisMatchingDecision = "Match with a supporting organisation";
             var initialDiagnosisMatchingDecisionNotes = "Random Notes";
 
-            var command = new SetRecordMatchingDecisionCommand(
+            var command = new SetRecordInitialDiagnosisDecisionCommand(
                 _mockSupportProject.Id,
                 regionalDirectorDecisionDate,
                 initialDiagnosisMatchingDecision,
@@ -49,7 +49,7 @@ namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportP
         public async Task Handle_ValidEmptyCommand_UpdatesSupportProject()
         {
             // Arrange
-            var command = new SetRecordMatchingDecisionCommand(
+            var command = new SetRecordInitialDiagnosisDecisionCommand(
                 _mockSupportProject.Id,
                 null,
                 null,
@@ -74,7 +74,7 @@ namespace Dfe.ManageSchoolImprovement.Application.Tests.CommandHandlers.SupportP
             var initialDiagnosisMatchingDecision = "Match with a supporting organisation";
             var initialDiagnosisMatchingDecisionNotes = "Random Notes";
 
-            var command = new SetRecordMatchingDecisionCommand(
+            var command = new SetRecordInitialDiagnosisDecisionCommand(
                 _mockSupportProject.Id,
                 regionalDirectorDecisionDate,
                 initialDiagnosisMatchingDecision,

--- a/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
@@ -237,7 +237,7 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             string? initialDiagnosisMatchingDecisionNotes = "Notes only if choose no";
 
             // Act
-            supportProject.SetRecordMatchingDecision(
+            supportProject.SetRecordInitialDiagnosisMatchingDecision(
                 regionalDirectorDecisionDate,
                 initialDiagnosisMatchingDecision,
                 initialDiagnosisMatchingDecisionNotes);
@@ -260,7 +260,7 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             string? initialDiagnosisMatchingDecisionNotes = "Notes only if choose no";
 
             // Act
-            supportProject.SetRecordMatchingDecision(
+            supportProject.SetRecordInitialDiagnosisMatchingDecision(
                 regionalDirectorDecisionDate,
                 initialDiagnosisMatchingDecision,
                 initialDiagnosisMatchingDecisionNotes);

--- a/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Domain.Tests/Entities/SupportProject/SupportProjectTests.cs
@@ -232,20 +232,20 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             // Arrange
             var supportProject = CreateSupportProject();
 
-            bool? hasSchoolMatchedWithSupportingOrganisation = false;
+            string? initialDiagnosisMatchingDecision = "Review school's progress";
             DateTime? regionalDirectorDecisionDate = DateTime.UtcNow;
-            string? notMatchingSchoolWithSupportingOrgNotes = "Notes only if choose no";
+            string? initialDiagnosisMatchingDecisionNotes = "Notes only if choose no";
 
             // Act
             supportProject.SetRecordMatchingDecision(
                 regionalDirectorDecisionDate,
-                hasSchoolMatchedWithSupportingOrganisation,
-                notMatchingSchoolWithSupportingOrgNotes);
+                initialDiagnosisMatchingDecision,
+                initialDiagnosisMatchingDecisionNotes);
 
             // Assert
-            supportProject.HasSchoolMatchedWithSupportingOrganisation.Should().Be(hasSchoolMatchedWithSupportingOrganisation);
+            supportProject.InitialDiagnosisMatchingDecision.Should().Be(initialDiagnosisMatchingDecision);
             supportProject.RegionalDirectorDecisionDate.Should().Be(regionalDirectorDecisionDate);
-            supportProject.NotMatchingSchoolWithSupportingOrgNotes.Should().Be(notMatchingSchoolWithSupportingOrgNotes);
+            supportProject.InitialDiagnosisMatchingDecisionNotes.Should().Be(initialDiagnosisMatchingDecisionNotes);
             mockRepository.VerifyAll();
         }
 
@@ -255,20 +255,20 @@ namespace Dfe.ManageSchoolImprovement.Domain.Tests.Entities.SupportProject
             // Arrange
             var supportProject = CreateSupportProject();
 
-            bool? hasSchoolMatchedWithSupportingOrganisation = true;
+            string? initialDiagnosisMatchingDecision = "Match with a supporting organisation";
             DateTime? regionalDirectorDecisionDate = DateTime.UtcNow;
-            string? notMatchingSchoolWithSupportingOrgNotes = "Notes only if choose no";
+            string? initialDiagnosisMatchingDecisionNotes = "Notes only if choose no";
 
             // Act
             supportProject.SetRecordMatchingDecision(
                 regionalDirectorDecisionDate,
-                hasSchoolMatchedWithSupportingOrganisation,
-                notMatchingSchoolWithSupportingOrgNotes);
+                initialDiagnosisMatchingDecision,
+                initialDiagnosisMatchingDecisionNotes);
 
             // Assert
-            supportProject.HasSchoolMatchedWithSupportingOrganisation.Should().Be(hasSchoolMatchedWithSupportingOrganisation);
+            supportProject.InitialDiagnosisMatchingDecision.Should().Be(initialDiagnosisMatchingDecision);
             supportProject.RegionalDirectorDecisionDate.Should().Be(regionalDirectorDecisionDate);
-            supportProject.NotMatchingSchoolWithSupportingOrgNotes.Should().Be(notMatchingSchoolWithSupportingOrgNotes);
+            supportProject.InitialDiagnosisMatchingDecisionNotes.Should().Be(initialDiagnosisMatchingDecisionNotes);
             mockRepository.VerifyAll();
         }
 

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/LinksTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/Models/LinksTests.cs
@@ -123,7 +123,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.Models
         [InlineData("/TaskList/CompleteAndSaveInitialDiagnosisAssessment/Index")]
         [InlineData("/TaskList/RecordVisitDateToVisitSchool/Index")]
         [InlineData("/TaskList/ChoosePreferredSupportingOrganisation/Index")]
-        [InlineData("/TaskList/RecordMatchingDecision/Index")]
+        [InlineData("/TaskList/RecordInitialDiagnosisDecision/Index")]
         [InlineData("/TaskList/AddSupportingOrganisationContactDetails/Index")]
         [InlineData("/TaskList/DueDiligenceOnPreferredSupportingOrganisation/Index")]
         [InlineData("/TaskList/RecordSupportingOrganisationAppointment/Index")]

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
@@ -153,9 +153,9 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.ViewModels
         {
             // Arrange
             var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(
-                1, 
-                DateTime.Now, 
-                AdviserVisitDate: adviserVisitDate, 
+                1,
+                DateTime.Now,
+                AdviserVisitDate: adviserVisitDate,
                 GiveTheAdviserTheNoteOfVisitTemplate: giveTheAdviserTheNoteOfVisitTemplate));
 
             //Action 
@@ -184,22 +184,26 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.ViewModels
             Assert.Equal(expectedTaskListStatus, taskListStatus);
         }
 
-        public static readonly TheoryData<DateTime?, bool?, string?, TaskListStatus> RecordSupportDecisionTaskListStatusCases = new()
+        public static readonly TheoryData<DateTime?, string?, string?, TaskListStatus> RecordSupportDecisionTaskListStatusCases = new()
         {
             { null, null, null, TaskListStatus.NotStarted },
-            { DateTime.Now, true, null, TaskListStatus.Complete },
-            { DateTime.Now, false, "Notes", TaskListStatus.InProgress }
+            { DateTime.Now, "Match with a supporting organisation", null, TaskListStatus.Complete },
+            { DateTime.Now, "Review school's progress", "Notes", TaskListStatus.Complete },
+            { DateTime.Now, "Unable to assess", "Notes", TaskListStatus.Complete },
+            { null, "Match with a supporting organisation", null, TaskListStatus.InProgress }
         };
 
         [Theory, MemberData(nameof(RecordSupportDecisionTaskListStatusCases))]
-        public void RecordMatchingDecisionTaskListStatusShouldReturnCorrectStatus(DateTime? regionalDirectorDecisionDate, bool? hasSchoolMatchedWithSupportingOrganisation, string? notMatchingSchoolWithSupportingOrgNotes, TaskListStatus expectedTaskListStatus)
+        public void RecordMatchingDecisionTaskListStatusShouldReturnCorrectStatus(DateTime? regionalDirectorDecisionDate, string? initialDiagnosisMatchingDecision, string? initialDiagnosisMatchingDecisionNotes, TaskListStatus expectedTaskListStatus)
         {
             // Arrange
-            var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(1, DateTime.Now, RegionalDirectorDecisionDate: regionalDirectorDecisionDate, HasSchoolMatchedWithSupportingOrganisation: hasSchoolMatchedWithSupportingOrganisation,
-                NotMatchingSchoolWithSupportingOrgNotes: notMatchingSchoolWithSupportingOrgNotes));
+            var supportProjectModel = SupportProjectViewModel.Create(new SupportProjectDto(1, DateTime.Now,
+                RegionalDirectorDecisionDate: regionalDirectorDecisionDate,
+                InitialDiagnosisMatchingDecision: initialDiagnosisMatchingDecision,
+                InitialDiagnosisMatchingDecisionNotes: initialDiagnosisMatchingDecisionNotes));
 
             //Action 
-            var taskListStatus = TaskStatusViewModel.RecordSupportDecisionTaskListStatus(supportProjectModel);
+            var taskListStatus = TaskStatusViewModel.RecordInitialDiagnosisDecisionTaskListStatus(supportProjectModel);
 
             //Assert
             Assert.Equal(expectedTaskListStatus, taskListStatus);


### PR DESCRIPTION
#### PR Classification
Refactor to update the matching decision logic in the application.

#### PR Summary
This pull request refactors the matching decision process by replacing the old parameters with new properties for initial diagnosis matching decision and notes. Key changes include:
- `SetRecordMatchingDecisionCommand`: Updated to use new string parameters for initial diagnosis matching decision and notes.
- `SupportProject`: Method modified to remove old parameters and incorporate new ones.
- `SupportProjectDto`: Class updated to include new properties and remove old school matching properties.
- Database migration files: Created to add new columns for initial diagnosis matching decision and notes while removing old columns.
- Front-end views: Updated to reflect new properties and adjust task list status methods accordingly.
