### PR TITLE
Removing reference to £120k+ funding availability

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ReviewTheImprovementPlan/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/ReviewTheImprovementPlan/Index.cshtml
@@ -113,11 +113,6 @@
                 </div>
             </details>
             <h2 class="govuk-heading-m">Select confirmed funding band</h2>
-            <p class="govuk-body">In some cases a school may require more than £120,000. If this is true for this school,
-                contact the grant team on 
-                <a class='govuk-link' href='mailto:@Model.EmailAddress?subject=Manage%20school%20improvement:%20support%20query'>
-                    @Model.EmailAddress
-                </a>.</p>
             <div class="govuk-form-group" id="funding-band">
                 <govuk-radiobuttons-input
                     heading-style="govuk-fieldset__legend--m"


### PR DESCRIPTION
This work removes paragraph text that references an additional layer of funding above £120,000 for rare exceptions. It was not a selectable option amongst the radio buttons.

## Before

<img width="813" height="461" alt="Screenshot 2025-07-16 at 10 08 06 am" src="https://github.com/user-attachments/assets/325b1d7c-f0dd-492e-8b69-cd0e2eadd460" />

## After

<img width="568" height="378" alt="Screenshot 2025-07-16 at 10 07 56 am" src="https://github.com/user-attachments/assets/ecaa27d5-0bf1-4b4e-9d7d-30055f63bde4" />
