### PR TITLE
Fix Cypress test

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/tasklist-neg-tests.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/tasklist-neg-tests.cy.ts
@@ -14,7 +14,10 @@ describe("Tasklist negative tests", () => {
     it("Should be able to validate Tasklist", () => {
 
         Logger.log("Selecting project");
-        homePage.selectSchoolName("Plymtree Church of England Primary School");
+        homePage
+            .selectProjectFilter("Plymtree Church of England Primary School")
+            .applyFilters()
+            .selectSchoolName("Plymtree Church of England Primary School");
         
         Logger.log("Validating date input field");
         taskList.selectTask("Contact the responsible body");


### PR DESCRIPTION
Cypress test 'tastklist-neg-tests.cy.ts' as failing due the the timeout issue . Actual reason was not to find the school in page 1 .
Fix- Use filters to find the school . 