### PR TITLE
Update cypress test

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/applyFilters.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/applyFilters.cy.ts
@@ -128,7 +128,7 @@ describe("User search results by applying filters", () => {
     });
 
     it("should filter projects by Advised by", () => {
-        const advisedBy = "test.test-rise@education.gov.uk";
+        const advisedBy = "TestFirstName TestSurname";
 
         Logger.log(`Testing - filter projects by Advised by: ${advisedBy}`);
         homePage

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/smoke/end-to-end-create-project.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/smoke/end-to-end-create-project.cy.ts
@@ -163,7 +163,7 @@ describe("User completes their newly created project", () => {
     Logger.log("Selecting 'Allocate an adviser' task");
     taskList.selectTask("Allocate an adviser");
     taskListActions.hasHeader("Allocate an adviser");
-    taskListActions.enterText("adviser-email-address", "adviser.email-rise@education.gov.uk");
+    taskListActions.enterText("adviser-email-address", "TestFirstName TestSurname");
     taskListActions.enterDate("date-adviser-allocated", "01", "01", "2024");
     taskListActions.selectButtonOrCheckbox("save-and-continue-button");
     taskList.hasFilterSuccessNotification()

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
@@ -68,8 +68,10 @@ class TaskList {
     cy.contains("Task list").first().should('have.attr', 'aria-current')
     cy.contains("About the school")
     cy.contains("Ofsted reports")
+    cy.contains("Improvement plan")
     cy.contains("Contacts")
     cy.contains("Case Study")
+    cy.contains("Engagement concern")
     cy.contains("Notes")
 
     return this;


### PR DESCRIPTION
This PR updates the filter test - now we are showing name to the `Advised by` filter instead of email
Also updated smoke test to include all Tabs 