### PR TITLE
Bug fix for invalid adviser date

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/AllocateAdviser/AllocateAdviser.cshtml.cs
@@ -64,6 +64,8 @@ public class AllocateAdviser(ISupportProjectQueryService supportProjectQueryServ
             _errorService.AddErrors(Request.Form.Keys, ModelState);
             ShowError = true;
             Referrer = referrer;
+            RiseAdvisers = await userRepository.GetAllRiseAdvisers();
+
             return await base.GetSupportProject(id, cancellationToken);
         }
 


### PR DESCRIPTION
#### PR Classification
Enhancement to error handling in the support project retrieval process.

#### PR Summary
This pull request adds functionality to retrieve all Rise Advisers when the model state is invalid, improving error handling in the support project process.
- `AllocateAdviser.cshtml.cs`: Added a line to call `await userRepository.GetAllRiseAdvisers();` when the model state is invalid.
