### PR TITLE
Fix cypress test workflow

### DIFF
--- a/.github/workflows/continuous-integration-cypress.yml
+++ b/.github/workflows/continuous-integration-cypress.yml
@@ -10,7 +10,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     defaults:
-      working-directory: src/Dfe.ManageSchoolImprovement.CypressTests
+      run:
+        working-directory: src/Dfe.ManageSchoolImprovement.CypressTests
     steps:
       - name: checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
* Fixes the `working-directory` parameter by adding `run` on the previous level