### PR TITLE
Add cypress test for Engagement concern and information powers

### DIFF
--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
@@ -1,0 +1,93 @@
+import engagementConcern from "cypress/pages/engagementConcern";
+import homePage from "cypress/pages/homePage";
+import taskList from "cypress/pages/taskList";
+import { Logger } from "cypress/common/logger";
+
+describe("User navigates to the Engagement Concern tab", () => {
+    beforeEach(() => {
+        cy.login();
+        homePage
+            .acceptCookies()
+            .selectFirstSchoolFromList()
+        taskList
+            .navigateToTab('Engagement concern')
+
+        cy.executeAccessibilityTests()
+    });
+
+    it("should be able to cancel recording the Engagement concern", () => {
+        Logger.log("check that Canel link works");
+        engagementConcern.clickRecordEngagementConcern()
+        engagementConcern.clickCancel();
+        engagementConcern.engagementConcernPageDisplayed();
+        cy.executeAccessibilityTests()
+    });
+
+
+    it("should be able to record the Engagement concern", () => {
+        Logger.log("record engagement concern");
+        engagementConcern.clickRecordEngagementConcern()
+        engagementConcern.hasTitle('Record engagement concern - Manage school improvement')
+        engagementConcern.checkCheckbox('record-engagement-concern')
+        engagementConcern.enterText("engagement-concern-details", "Recording new engagement concern")
+
+        cy.executeAccessibilityTests()
+
+        engagementConcern.clickSaveAndReturn();
+        engagementConcern.hasSuccessNotification("Engagement concern recorded");
+        engagementConcern.hasFieldsNotEmpty();
+        engagementConcern.hasEngagementConcernChangeLink("Change");
+        engagementConcern.hasEscalateLink("Escalate");
+
+        cy.executeAccessibilityTests()
+    });
+
+    it("should be able to cancel recording the Use of Information powers", () => {
+        Logger.log("check that Canel link works for Information powers");
+        engagementConcern.clickRecordUserOfInformationPowersButton()
+        engagementConcern.clickCancel();
+        engagementConcern.engagementConcernPageDisplayed();
+
+        cy.executeAccessibilityTests()
+    });
+
+
+    it("should be able to Record use of information powers ", () => {
+        Logger.log("record information powers in use");
+        engagementConcern.clickRecordUserOfInformationPowersButton()
+        engagementConcern.checkCheckbox('information-powers-in-use');
+        engagementConcern.enterText("information-powers-details", "Details about why and how the powers have been used");
+        engagementConcern.enterDate("powers-used-date", "5", "10", "2024");
+
+        cy.executeAccessibilityTests()
+
+        engagementConcern.clickSaveAndReturn();
+        engagementConcern.hasSuccessNotification("Use of information powers recorded");
+        engagementConcern.hasFieldsNotEmpty();
+        engagementConcern.hasInformationPowersChangeLink("Change");
+
+        cy.executeAccessibilityTests();
+    })
+
+    it("should be able to Change Engagement Concern ", () => {
+        Logger.log("change engagement concern");
+        engagementConcern.hasEngagementConcernChangeLink("Change")
+        engagementConcern.clickEngagementConcernChangeLink();
+        engagementConcern.enterText("engagement-concern-details", "Add new details");
+        engagementConcern.clickSaveAndReturn();
+        engagementConcern.hasSuccessNotification("Engagement concern updated");
+
+        cy.executeAccessibilityTests();
+    })
+
+    it("should be able to Change Information Powers ", () => {
+        Logger.log("change information powers");
+        engagementConcern.hasInformationPowersChangeLink("Change")
+        engagementConcern.clickInformationPowersChangeLink();
+        engagementConcern.enterText("information-powers-details", "Add new details");
+        engagementConcern.clickSaveAndReturn();
+        engagementConcern.hasSuccessNotification("Information powers updated");
+
+        cy.executeAccessibilityTests();
+    })
+});

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
@@ -3,7 +3,7 @@ import homePage from "cypress/pages/homePage";
 import taskList from "cypress/pages/taskList";
 import { Logger } from "cypress/common/logger";
 
-describe("User navigates to the Engagement Concern tab", () => {
+describe("User navigates to the Engagement Concern tab to record Engagement concern and information powers", () => {
     beforeEach(() => {
         cy.login();
         homePage

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/e2e/record-engagement-concern.cy.ts
@@ -29,9 +29,14 @@ describe("User navigates to the Engagement Concern tab to record Engagement conc
         engagementConcern.clickRecordEngagementConcern()
         engagementConcern.hasTitle('Record engagement concern - Manage school improvement')
         engagementConcern.checkCheckbox('record-engagement-concern')
-        engagementConcern.enterText("engagement-concern-details", "Recording new engagement concern")
+
+        //save without entering details and validate error message
+         engagementConcern.clickSaveAndReturn();
+         engagementConcern.errorMessage('more-detail-error', 'You must enter details')
 
         cy.executeAccessibilityTests()
+
+        engagementConcern.enterText("engagement-concern-details", "Recording new engagement concern")
 
         engagementConcern.clickSaveAndReturn();
         engagementConcern.hasSuccessNotification("Engagement concern recorded");

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/engagementConcern.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/engagementConcern.ts
@@ -1,14 +1,147 @@
 class EngagementConcern {
 
-
     public engagementConcernPageDisplayed(): this {
         cy.url().should('include', '/engagement-concern');
         cy.contains('Page not found').should('not.exist');
 
         return this;
     }
+
+    public clickRecordEngagementConcern(): this {
+        cy.get('body').then($body => {
+            const buttonExists = $body.find('[role="button"]:contains("Record engagement concern")').length > 0;
+
+            if (buttonExists) {
+                cy.get('[role="button"]').contains('Record engagement concern').click({ force: true });
+                cy.log('Clicked Record engagement concern button');
+            } else {
+                expect(buttonExists, 'Engagement concern already existing').to.be.true;
+            }
+        });
+
+        return this;
+    }
+
+    public hasTitle(expectedTitle: string): this {
+        cy.title().should('eq', expectedTitle);
+
+        return this;
+    }
+
+    public recordConcernPageIsVisible(): this {
+        cy.url().should('include', '/record-engagement-concern');
+        cy.title().should('eq', 'Record engagement concern - Manage school improvement');
+
+        return this;
+    }
+
+    public clickRecordUserOfInformationPowersButton(): this {
+        cy.get('body').then($body => {
+            const buttonExists = $body.find('[role="button"]:contains("Record use of information powers")').length > 0;
+
+            if (buttonExists) {
+                cy.get('[role="button"]').contains('Record use of information powers').click({ force: true });
+                cy.log('Clicked Record use of information powers');
+            } else {
+                expect(buttonExists, 'Use of Information powers already existing').to.be.true;
+            }
+        });
+
+        return this;
+    }
+
+    public clickCancel(): this {
+        cy.get('a').contains('Cancel').click();
+
+        return this;
+    }
+
+
+    public checkCheckbox(id: string): this {
+        cy.getById(id).check();
+
+        return this;
+    }
+
+
+    public enterText(id: string, text: string): this {
+        cy.getById(id).clear().type(text);
+
+        return this;
+    }
+
+    public enterDate(dateFieldId: string, day: string, month: string, year: string): this {
+        cy.getById(`${dateFieldId}-day`).clear().type(day);
+        cy.getById(`${dateFieldId}-month`).clear().type(month);
+        cy.getById(`${dateFieldId}-year`).clear().type(year);
+
+        return this;
+    }
+
+    public clickSaveAndReturn(): this {
+        cy.get('[type="submit"]').should('contain', 'Save and return')
+            .click();
+
+        return this;
+    }
+
+    public hasSuccessNotification(expectedMessage: string): this {
+        cy.get('.govuk-notification-banner--success')
+            .should('be.visible')
+            .find('.govuk-notification-banner__content')
+            .should('contain', expectedMessage);
+
+        return this;
+    }
+
+    public hasFieldsNotEmpty(): this {
+        cy.get('.govuk-summary-list__value').each(($el) => {
+            cy.wrap($el).should('not.be.empty');
+        });
+
+        return this;
+    }
+
+    public hasEngagementConcernChangeLink(linkText: string): this {
+        cy.get('[data-cy="engagement-concern-change-link"]')
+            .should('be.visible')
+            .contains(linkText);
+
+        return this;
+    }
+
+    public clickEngagementConcernChangeLink(): this {
+        cy.getByCyData('engagement-concern-change-link').click();
+        cy.url().should('include', '/change-engagement-concern');
+
+        return this;
+
+    }
+
+    public hasInformationPowersChangeLink(linkText: string): this {
+        cy.get('[data-cy="information-powers-change-link"]')
+            .should('be.visible')
+            .contains(linkText);
+
+        return this;
+    }
+
+    public clickInformationPowersChangeLink(): this {
+        cy.getByCyData('information-powers-change-link').click();
+        cy.url().should('include', '/change-use-of-information-powers');
+
+        return this;
+
+    }
+
+    public hasEscalateLink(linkText: string): this {
+        cy.getByCyData('engagement-concern-escalate-link')
+            .should('be.visible')
+            .contains(linkText)
+
+        return this;
+    }
 }
 
 const engagementConcern = new EngagementConcern();
-
 export default engagementConcern;

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/engagementConcern.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/engagementConcern.ts
@@ -85,6 +85,12 @@ class EngagementConcern {
         return this;
     }
 
+    public errorMessage(id: string, message: string): this {
+        cy.getById(id).should('contain', message);
+
+        return this;
+    }
+
     public hasSuccessNotification(expectedMessage: string): this {
         cy.get('.govuk-notification-banner--success')
             .should('be.visible')

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/homePage.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/homePage.ts
@@ -36,6 +36,13 @@ class HomePage {
     return this;
   }
 
+  public acceptCookies(): this {
+    cy.get('[data-test="cookie-banner-accept"]').contains('Accept analytics cookies').click()
+    cy.get('.govuk-cookie-banner__heading').should('not.be.visible') 
+    
+    return this;
+  }
+
   public viewCookiesPage(): this {
     cy.get('[data-test="cookie-banner-link-1"]').click()
     cy.url().should('include', '/cookie-preferences')

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
@@ -16,31 +16,26 @@ class TaskList {
     return this;
   }
 
-  // Assert 'Date of last OFSTED inspection' matches the expected value
   public hasInspectionDate(date: string): this {
     cy.get('.govuk-summary-list__value').eq(1).should("contain.text", date);
     return this;
   }
 
-  // Assert 'Quality of education' matches the expected value
   public hasQualityOfEducation(value: string): this {
     cy.get('.govuk-summary-list__value').eq(2).should("contain.text", value);
     return this;
   }
 
-  // Assert 'Leadership and management' matches the expected value
   public hasLeadershipAndManagement(value: string): this {
     cy.get('.govuk-summary-list__value').eq(3).should("contain.text", value);
     return this;
   }
 
-  // Assert 'Assigned to' matches the expected value
   public hasAssignedTo(value: string): this {
     cy.get('.govuk-summary-list__value').eq(4).should("contain.text", value);
     return this;
   }
 
-  // Assert 'Advised by' matches the expected value
   public hasAdvisedBy(value: string): this {
     cy.get('.govuk-summary-list__value').eq(5).should("contain.text", value);
     return this;
@@ -143,7 +138,7 @@ class TaskList {
   }
 
   public navigateToTab(tabName: string): this {
-    cy.get('.moj-sub-navigation__item')
+    cy.get('.moj-sub-navigation__link')
       .contains(tabName).click();
 
     return this;

--- a/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
+++ b/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/pages/taskList.ts
@@ -10,7 +10,6 @@ class TaskList {
     return this
   }
 
-  // Assert 'Date Added' matches the expected value
   public hasDateAdded(date: string): this {
     cy.get('.govuk-summary-list__value').eq(0).should("contain.text", date);
     return this;


### PR DESCRIPTION
This PR covers the test cases for Engagement Concern and Information powers
- Record the Engagement concern
- Record the Information powers
- Change the Engagement concern
- Change the Information powers
- Cancel  whilst recording
- Success messages
- Failure message for text field