### PR TITLE
Update Release notes 

### DIFF
--- a/release-notes–manage-school-improvement.md
+++ b/release-notes–manage-school-improvement.md
@@ -3,6 +3,22 @@
 Welcome to the release notes for **Manage School Improvement**. Here you'll find a summary of key changes, improvements, and fixes over time.
 ---
 
+## 📅 [v1.0.0] - Q2 – Sprint 5 (Part 1) - 2025-09-04
+
+### 📌 User Stories
+
+- **225330** - Monitoring- View or record progress against objectives
+- **232183** - Monitoring- make it mandatory to complete both the progress and details fields when reviewing progress towards objectives
+- **231322** - Monitoring- Record and view overall school progress
+- **224088** - Add new "Make initial contact with the responsible body" task
+- **224071** - Update "Contact the responsible body" task to "Send the formal notification"
+
+### 🐛 Bug Fixes
+
+- **234632** - H2 heading font size not very distinct from paragraph text
+
+--
+
 ## 📅 [v0.15.0] - Q2 – Sprint 4 (Part 1) - 2025-08-18
 
 ### 📌 User Stories


### PR DESCRIPTION
Updated release notes for Monitoring and begin the project changes : 

**User Stories**

225330 - Monitoring- View or record progress against objectives
232183 - Monitoring- make it mandatory to complete both the progress and details fields when reviewing progress towards objectives
231322 - Monitoring- Record and view overall school progress
224088 - Add new "Make initial contact with the responsible body" task
224071 - Update "Contact the responsible body" task to "Send the formal notification"

 **Bug Fixes**
234632 - H2 heading font size not very distinct from paragraph text