### PR TITLE
Adding numbers list of steps to follow to escalation confirmation page

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/EscalateEngagementConcern/EscalationConfirmation.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/EscalateEngagementConcern/EscalationConfirmation.cshtml
@@ -34,6 +34,23 @@
         <h2 class="govuk-heading-m">Check which notice to use</h2>
         <p class="govuk-body">If it is a local authority maintained school, send the Notice to Enter into Arrangements.</p>
         <p class="govuk-body">If it is an academy, send the Termination Warning Notice.</p>
+        <h2 class="govuk-heading-m">Preparing and issuing the notice</h2>
+        <p class="govuk-body">You must complete the following steps before you can use a notice to mandate engagement.</p>
+        <ol class="govuk-list govuk-list--number">
+            <li>Use existing relationships to encourage voluntary engagement. </li>
+            <li>Follow the mediation process to resolve issues informally.</li>
+            <li>Consider the use of information powers if mediation fails.</li>
+            <li>Gather evidence to show mandation is necessary.</li>
+            <li>Get approval in principle to mandate from a regional director.</li>
+            <li>Complete the mandation moderation process.</li>
+            <li>Draft the notice.</li>
+            <li>Consult the trust relationship manager or local autority lead about the actions in the notice, the notification letter and any contextual information that may help.</li>
+            <li>Carry out the Public Sector Equality Duty assessment and save it in SharePoint.</li>
+            <li><a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/Commissioning%20Form.aspx" class="govuk-link" rel="noreferrer noopener" target="_blank">Use the SOPU commissioning form (opens in new tab)</a> to submit the draft notice to SOPU for Legal Advisers Office clearance.</li>
+            <li>Notify the school's responsible body, and diocese or foundation governors if applicable.</li>
+            <li>Send the notice to the school and responsible body from the regional director's mailbox.</li>
+            <li><a href="https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/Commissioning%20Form.aspx" class="govuk-link" rel="noreferrer noopener" target="_blank">Complete the SOPU commissioning form (opens in new tab)</a> to request they record the notice in the Warning Notice Tracker.</li>
+        </ol>
         <h2 class="govuk-heading-m">Use the letter and notice templates</h2>
         <p class="govuk-body">The letters and notices are templated. You must use these to make sure information in them is legally compliant.</p>
         


### PR DESCRIPTION
This work adds a heading, paragraph text and a numbers list to the escalation confirmation page.

There are 2 links to the SOPU commissioning form in the numbered list. They should point to https://educationgovuk.sharepoint.com/sites/lvewp00030/SitePages/Commissioning%20Form.aspx and open in a new tab.

## Before

<img width="1223" height="1617" alt="localhost_7088_engagement-concern_confirm-escalation_504" src="https://github.com/user-attachments/assets/36665a38-a1b9-4485-b913-8b545325fdfe" />

## After

<img width="1223" height="2233" alt="localhost_7088_engagement-concern_confirm-escalation_504 (1)" src="https://github.com/user-attachments/assets/867f0031-6379-428b-8196-aea708e57ac2" />
