### PR TITLE
Engagement concer bugfix

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/AssignToDifferentConcern.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/AssignToDifferentConcern.cshtml
@@ -76,7 +76,7 @@
             else
             {
                 <h1 class="govuk-heading-l">Assign to different concern</h1>
-                <p class="govuk-body">You cannot assign this @(Model.AssignType == AssignToDifferentConcernModel.AssignInfoPowersToDifferentConcern ? "use of information powers" : "use of interim executive board") to another engagement cocnern.</p>
+                <p class="govuk-body">You cannot assign this @(Model.AssignType == AssignToDifferentConcernModel.AssignInfoPowersToDifferentConcern ? "use of information powers" : "use of interim executive board") to another engagement concern.</p>
                 <p>There are no other active concerns. </p>
                 <a asp-page="@Model.ReturnPage" asp-route-id="@Model.SupportProject.Id" class="govuk-button">Go back</a>
             }

--- a/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/Index.cshtml
@@ -78,7 +78,7 @@
                             Record use of information powers
                         </a>
                     }
-                    else
+                    else if (!Model.AllEngagementConcernsResolved)
                     {
                         <a asp-page="@Links.EngagementConcern.SelectRelevantConcern.Page"
                            asp-route-id="@Model.SupportProject.Id"
@@ -104,7 +104,7 @@
                                 Record use of interim executive board
                             </a>
                         }
-                        else
+                        else if (!Model.AllEngagementConcernsResolved)
                         {
                             <a asp-page="@Links.EngagementConcern.SelectRelevantConcern.Page"
                                asp-route-id="@Model.SupportProject.Id"

--- a/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/EngagementConcern/Index.cshtml.cs
@@ -41,7 +41,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
     public bool? InterimExecutiveBoardDateUpdated { get; set; }
 
     public List<EngagementConcernViewModel> EngagementConcerns { get; set; } = [];
-
+    public bool AllEngagementConcernsResolved { get; private set; } = true;
     public int ActiveEngagementConcernsWithoutIebCount { get; set; } = 0;
     public bool ActiveEngagementConcernsWithIeb { get; set; } = false;
     public int? EngagementConcernWithoutIebReadableId { get; set; } = null;
@@ -59,7 +59,7 @@ public class IndexModel(ISupportProjectQueryService supportProjectQueryService, 
         await base.GetSupportProject(id, cancellationToken);
 
         EngagementConcerns = SupportProject?.EngagementConcerns?.OrderByDescending(x => x.EngagementConcernRaisedDate).ToList() ?? [];
-
+        AllEngagementConcernsResolved = !EngagementConcerns.Any(x => x.EngagementConcernResolved != true);
         // we need to know what page to navigate to associate ieb and information powers, if there are multiple per category then we have to go to the select relevant concern page
         // else we go to the next avaialable concern
         ActiveEngagementConcernsWithoutIebCount = EngagementConcerns.Where(x => x.EngagementConcernResolved != true && x.InterimExecutiveBoardCreated != true).Count();


### PR DESCRIPTION
#### PR Classification
Bug fix and code improvement.

#### PR Summary
This pull request corrects a typo in the user message and enhances the logic for handling engagement concerns in the application. 
- `AssignToDifferentConcern.cshtml`: Fixed a typo from "cocnern" to "concern".
- `Index.cshtml`: Updated conditional logic to check if all engagement concerns are resolved before rendering buttons.
- `IndexModel`: Added `AllEngagementConcernsResolved` property to track the resolution state of engagement concerns.
- `IndexModel`: Refined logic for counting active engagement concerns without interim executive boards and with interim executive boards.
