### PR TITLE
sonar fixes

### DIFF
--- a/SonarQube.Analysis.xml
+++ b/SonarQube.Analysis.xml
@@ -6,7 +6,12 @@
 	<Property Name="sonar.coverageReportPaths">./src/CoverageReport/SonarQube.xml</Property>
 
 	<!-- analysis exclusions -->
-	<Property Name="sonar.exclusions">**/src/Dfe.ManageSchoolImprovement/**/*.cshtml,**/src/Dfe.ManageSchoolImprovement/**/*.cshtml.cs,**/Migrations/**,**/src/Dfe.ManageSchoolImprovement/wwwroot/**</Property>
+	<Property Name="sonar.exclusions">**/src/Dfe.ManageSchoolImprovement/**/*.cshtml,
+		**/src/Dfe.ManageSchoolImprovement/**/*.cshtml.cs,
+		**/Migrations/**,
+		**/src/Dfe.ManageSchoolImprovement/wwwroot/**,
+		**/src/Dfe.ManageSchoolImprovement.CypressTests/tsconfig.json
+	</Property>
 
 	<!-- coverage exclusions -->
 	<Property Name="sonar.coverage.exclusions">

--- a/src/Dfe.ManageSchoolImprovement/Services/EstablishmentService.cs
+++ b/src/Dfe.ManageSchoolImprovement/Services/EstablishmentService.cs
@@ -1,3 +1,4 @@
+using System.Web;
 using Dfe.ManageSchoolImprovement.Frontend.Models;
 using Dfe.ManageSchoolImprovement.Frontend.Services.Dtos;
 using Dfe.ManageSchoolImprovement.Frontend.Services.Http;
@@ -15,13 +16,13 @@ public class EstablishmentService(IDfeHttpClientFactory httpClientFactory,
 
     public async Task<EstablishmentDto> GetEstablishmentByUrn(string urn)
     {
-        HttpResponseMessage response = await _httpClient.GetAsync($"/v4/establishment/urn/{urn}");
+        HttpResponseMessage response = await _httpClient.GetAsync($"/v4/establishment/urn/{HttpUtility.UrlEncode(urn)}");
         if (!response.IsSuccessStatusCode)
         {
             logger.LogWarning("Unable to get establishment data for establishment with URN: {Urn}", urn);
             return new EstablishmentDto();
         }
-
+    
         return await response.Content.ReadFromJsonAsync<EstablishmentDto>();
     }
     public async Task<MisEstablishmentResponse> GetEstablishmentOfstedDataByUrn(string urn)


### PR DESCRIPTION
- fix get establishment by urn method to not construct url from user-controlled data
- exclude tsconfig.json file from sonar coverage