### PR TITLE
match with supporting org tasks not available for review progress schools

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Models/TaskListStatus.cs
+++ b/src/Dfe.ManageSchoolImprovement/Models/TaskListStatus.cs
@@ -7,4 +7,5 @@ public enum TaskListStatus
     Complete,
     CannotProgress,
     CannotStartYet,
+    NotRequired
 }

--- a/src/Dfe.ManageSchoolImprovement/Pages/Shared/_TaskListStatus.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/Shared/_TaskListStatus.cshtml
@@ -22,6 +22,10 @@
             output = "Cannot start yet";
             colour = "grey";
             break;
+        case TaskListStatus.NotRequired:
+            output = "Not Required";
+            colour = "grey";
+            break;
         case TaskListStatus.NotStarted:
         default:
             output = "Not Started";

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -330,7 +330,6 @@
             </ul>
         </div>
         
-        @* all below here have non-link version for review progress school *@
         <h3 class="app-task-list__section govuk-!-margin-top-8">Find possible supporting organisation</h3>
         <div>
             <ul class="govuk-task-list">

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml
@@ -232,108 +232,110 @@
                         </div>
                     }
                     <div class="govuk-task-list__status" id="send-introductory-email-request-improvement-plan_status">
-                            <partial name="Shared/_TaskListStatus" model="@Model.SendIntroductoryEmailTaskListStatus"/>
-                        </div>
+                        <partial name="Shared/_TaskListStatus" model="@Model.SendIntroductoryEmailTaskListStatus"/>
+                    </div>
                     
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        <a class="govuk-link govuk-task-list__link"
-                           asp-page="@Links.TaskList.ArrangeAdvisersFirstFaceToFaceVisit.Page"
-                           asp-route-id="@Model.SupportProject.Id" data-cy="adviser-school-visit"
-                           aria-describedby="adviser-school-visit_status">
+                    @if (Model.AdviserSet == true)
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
+                            <a class="govuk-link govuk-task-list__link"
+                               asp-page="@Links.TaskList.ArrangeAdvisersFirstFaceToFaceVisit.Page"
+                               asp-route-id="@Model.SupportProject.Id" data-cy="adviser-school-visit"
+                               aria-describedby="adviser-school-visit_status">
+                                Arrange adviser's initial visit
+                            </a>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                             Arrange adviser's initial visit
-                        </a>
-                    </div>
-                }
-                else
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        Arrange adviser's initial visit
-                    </div>
-                }
-                <div class="govuk-task-list__status" id="adviser-school-visit_status">
+                        </div>
+                    }
+                    <div class="govuk-task-list__status" id="adviser-school-visit_status">
                         <partial name="Shared/_TaskListStatus"
                                  model="@Model.ArrangeAdvisersFirstFaceToFaceVisitTaskListStatus"/>
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        <a class="govuk-link govuk-task-list__link"
-                           asp-page="@Links.TaskList.RecordVisitDateToVisitSchool.Page"
-                           asp-route-id="@Model.SupportProject.Id" data-cy="record-school-visit-date"
-                           aria-describedby="record-school-visit-date_status">
+                    @if (Model.AdviserSet == true)
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
+                            <a class="govuk-link govuk-task-list__link"
+                               asp-page="@Links.TaskList.RecordVisitDateToVisitSchool.Page"
+                               asp-route-id="@Model.SupportProject.Id" data-cy="record-school-visit-date"
+                               aria-describedby="record-school-visit-date_status">
+                                Record date of initial visit
+                            </a>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                             Record date of initial visit
-                        </a>
-                    </div>
-                }
-                else
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        Record date of initial visit
-                    </div>
-                }
-                <div class="govuk-task-list__status" id="record-school-visit-date_status">
+                        </div>
+                    }
+                    <div class="govuk-task-list__status" id="record-school-visit-date_status">
                         <partial name="Shared/_TaskListStatus"
                                  model="@Model.RecordVisitDateToVisitSchoolTaskListStatus"/>
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        <a class="govuk-link govuk-task-list__link"
-                           asp-page="@Links.TaskList.CompleteAndSaveInitialDiagnosisAssessment.Page"
-                           asp-route-id="@Model.SupportProject.Id" data-cy="complate-save-assessment-template"
-                           aria-describedby="complate-save-assessment-template_status">
+                    @if (Model.AdviserSet == true)
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
+                            <a class="govuk-link govuk-task-list__link"
+                               asp-page="@Links.TaskList.CompleteAndSaveInitialDiagnosisAssessment.Page"
+                               asp-route-id="@Model.SupportProject.Id" data-cy="complate-save-assessment-template"
+                               aria-describedby="complate-save-assessment-template_status">
+                                Complete and save the initial diagnosis assessment
+                            </a>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                             Complete and save the initial diagnosis assessment
-                        </a>
-                    </div>
-                }
-                else
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        Complete and save the initial diagnosis assessment
-                    </div>
-                }
-                <div class="govuk-task-list__status" id="complate-save-assessment-template_status">
+                        </div>
+                    }
+                    <div class="govuk-task-list__status" id="complate-save-assessment-template_status">
                         <partial name="Shared/_TaskListStatus"
                                  model="@Model.CompleteAndSaveInitialDiagnosisTemplateTaskListStatus"/>
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        <a class="govuk-link govuk-task-list__link"
-                           asp-page="@Links.TaskList.RecordInitialDiagnosisDecision.Page"
-                           asp-route-id="@Model.SupportProject.Id" data-cy="record-support-decision"
-                           aria-describedby="record-support-decision_status">
+                    @if (Model.AdviserSet == true)
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
+                            <a class="govuk-link govuk-task-list__link"
+                               asp-page="@Links.TaskList.RecordInitialDiagnosisDecision.Page"
+                               asp-route-id="@Model.SupportProject.Id" data-cy="record-support-decision"
+                               aria-describedby="record-support-decision_status">
+                                Record initial diagnosis decision
+                            </a>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                             Record initial diagnosis decision
-                        </a>
-                    </div>
-                }
-                else
-                {
-                    <div class="govuk-task-list__name-and-hint" data-cy="task-name">
-                        Record initial diagnosis decision
-                    </div>
-                }
-                <div class="govuk-task-list__status" id="record-support-decision_status">
+                        </div>
+                    }
+                    <div class="govuk-task-list__status" id="record-support-decision_status">
                         <partial name="Shared/_TaskListStatus" model="@Model.RecordSupportDecisionTaskListStatus"/>
                     </div>
                 </li>
             </ul>
         </div>
+        
+        @* all below here have non-link version for review progress school *@
         <h3 class="app-task-list__section govuk-!-margin-top-8">Find possible supporting organisation</h3>
         <div>
             <ul class="govuk-task-list">
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         @if (!string.IsNullOrEmpty(Model.SupportProject.SupportOrganisationName)
@@ -374,7 +376,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -399,7 +401,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hintme" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -424,7 +426,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -455,7 +457,7 @@
         <div>
             <ul class="govuk-task-list">
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -478,7 +480,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -506,7 +508,7 @@
         <div>
             <ul class="govuk-task-list">
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -529,7 +531,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -552,7 +554,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -575,7 +577,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -598,7 +600,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         @if (Model.SupportProject.ImprovementPlans != null
@@ -643,7 +645,7 @@
         <div>
             <ul class="govuk-task-list">
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"
@@ -667,7 +669,7 @@
                     </div>
                 </li>
                 <li class="govuk-task-list__item govuk-task-list__item--with-link">
-                @if (Model.AdviserSet == true)
+                @if (Model.AdviserSet == true && Model.ReviewProgressSchool == false)
                 {
                     <div class="govuk-task-list__name-and-hint" data-cy="task-name">
                         <a class="govuk-link govuk-task-list__link"

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
@@ -53,10 +53,12 @@ public class IndexModel(
     public TaskListStatus EnterImprovementPlanObjectivesTaskListStatus { get; set; }
 
     public bool ProjectNotYetAssigned { get; set; }
-    
+
     public bool? AdviserCanBeSet { get; set; }
-    
+
     public bool? AdviserSet { get; set; }
+
+    public bool? ReviewProgressSchool { get; set; }
 
     public void SetErrorPage(string errorPage)
     {
@@ -77,14 +79,15 @@ public class IndexModel(
             var projectStatusPausedOrStopped = SupportProject.ProjectStatus != ProjectStatusValue.InProgress;
             ProjectNotYetAssigned = !SupportProject.InitialDeliveryOfficerAssigned;
             AdviserCanBeSet = SupportProject.AdviserCanBeSet;
+            ReviewProgressSchool = SupportProject.InitialDiagnosisMatchingDecision == ReviewProgress;
 
             AdviserSet = !string.IsNullOrWhiteSpace(SupportProject.AdviserFullName);
-            
+
             // phase one tasks
             ConfirmEligibilityTaskListStatus = projectStatusPausedOrStopped
                 ? TaskListStatus.CannotProgress
                 : TaskStatusViewModel.ConfirmEligibilityTaskListStatus(SupportProject);
-            
+
             if (projectStatusPausedOrStopped)
             {
                 FundingHistoryStatus = TaskListStatus.CannotProgress;
@@ -127,7 +130,7 @@ public class IndexModel(
                 AllocateAdviserTaskListStatus = TaskStatusViewModel.CheckAllocateAdviserTaskListStatus(SupportProject);
             }
 
-            if(projectStatusPausedOrStopped)
+            if (projectStatusPausedOrStopped)
             {
                 // Phase 2
                 SendIntroductoryEmailTaskListStatus = TaskListStatus.CannotProgress;
@@ -143,7 +146,8 @@ public class IndexModel(
                 // Phase 3
                 RequestPlanningGrantOfferLetterTaskListStatus = TaskListStatus.CannotProgress;
                 ConfirmPlanningGrantOfferLetterTaskListStatus = TaskListStatus.CannotProgress;
-                ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus = TaskListStatus.CannotProgress;
+                ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus =
+                    TaskListStatus.CannotProgress;
                 ReviewTheImprovementPlanTaskListStatus = TaskListStatus.CannotProgress;
                 SendAgreedImprovementPlanForApprovalTaskListStatus = TaskListStatus.CannotProgress;
                 RecordImprovementPlanDecisionTaskListStatus = TaskListStatus.CannotProgress;
@@ -168,7 +172,8 @@ public class IndexModel(
                 // Phase 3
                 RequestPlanningGrantOfferLetterTaskListStatus = TaskListStatus.CannotStartYet;
                 ConfirmPlanningGrantOfferLetterTaskListStatus = TaskListStatus.CannotStartYet;
-                ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus = TaskListStatus.CannotStartYet;
+                ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus =
+                    TaskListStatus.CannotStartYet;
                 ReviewTheImprovementPlanTaskListStatus = TaskListStatus.CannotStartYet;
                 SendAgreedImprovementPlanForApprovalTaskListStatus = TaskListStatus.CannotStartYet;
                 RecordImprovementPlanDecisionTaskListStatus = TaskListStatus.CannotStartYet;
@@ -176,7 +181,6 @@ public class IndexModel(
                 RequestImprovementGrantOfferLetterTaskListStatus = TaskListStatus.CannotStartYet;
                 ConfirmImprovementGrantOfferLetterTaskListStatus = TaskListStatus.CannotStartYet;
             }
-            // Phase two tasks
 
             else
             {
@@ -191,44 +195,70 @@ public class IndexModel(
                     TaskStatusViewModel.CompleteAndSaveInitialDiagnosisTemplateTaskListStatus(SupportProject);
                 RecordSupportDecisionTaskListStatus =
                     TaskStatusViewModel.RecordInitialDiagnosisDecisionTaskListStatus(SupportProject);
-                ChosePreferredSupportingOrganisationTaskListStatus =
-                    TaskStatusViewModel.ChoosePreferredSupportingOrganisationTaskListStatus(SupportProject);
-                DueDiligenceOnPreferredSupportingOrganisationTaskListStatus =
-                    TaskStatusViewModel.DueDiligenceOnPreferredSupportingOrganisationTaskListStatus(SupportProject);
-                SetRecordSupportingOrganisationAppointment =
-                    TaskStatusViewModel.SetRecordSupportingOrganisationAppointmentTaskListStatus(SupportProject);
-                SupportingOrganisationContactDetailsTaskListStatus =
-                    TaskStatusViewModel.SupportingOrganisationContactDetailsTaskListStatus(SupportProject);
 
-                // Phase 3
-                RequestPlanningGrantOfferLetterTaskListStatus =
-                    TaskStatusViewModel.RequestPlanningGrantOfferLetterTaskListStatus(SupportProject);
-                ConfirmPlanningGrantOfferLetterTaskListStatus =
-                    TaskStatusViewModel.ConfirmPlanningGrantOfferLetterTaskListStatus(SupportProject);
-                ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus =
-                    TaskStatusViewModel.ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus(
-                        SupportProject);
-                ReviewTheImprovementPlanTaskListStatus =
-                    TaskStatusViewModel.ReviewTheImprovementPlanTaskListStatus(SupportProject);
-                SendAgreedImprovementPlanForApprovalTaskListStatus =
-                    TaskStatusViewModel.SendAgreedImprovementPlanForApprovalTaskListStatus(SupportProject);
-                RecordImprovementPlanDecisionTaskListStatus =
-                    TaskStatusViewModel.RecordImprovementPlanDecisionTaskListStatus(SupportProject);
-                EnterImprovementPlanObjectivesTaskListStatus =
-                    TaskStatusViewModel.EnterImprovementPlanObjectivesTaskListStatus(SupportProject);
-                RequestImprovementGrantOfferLetterTaskListStatus =
-                    TaskStatusViewModel.RequestImprovementGrantOfferLetterTaskListStatus(SupportProject);
-                ConfirmImprovementGrantOfferLetterTaskListStatus =
-                    TaskStatusViewModel.ConfirmImprovementGrantOfferLetterTaskListStatus(SupportProject);
+                if (ReviewProgressSchool == true)
+                {
+                    ChosePreferredSupportingOrganisationTaskListStatus = TaskListStatus.NotRequired;
+                    DueDiligenceOnPreferredSupportingOrganisationTaskListStatus = TaskListStatus.NotRequired;
+                    SetRecordSupportingOrganisationAppointment = TaskListStatus.NotRequired;
+                    SupportingOrganisationContactDetailsTaskListStatus = TaskListStatus.NotRequired;
+
+                    // Phase 3
+                    RequestPlanningGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
+                    ConfirmPlanningGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
+                    ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus = TaskListStatus.NotRequired;
+                    ReviewTheImprovementPlanTaskListStatus = TaskListStatus.NotRequired;
+                    SendAgreedImprovementPlanForApprovalTaskListStatus = TaskListStatus.NotRequired;
+                    RecordImprovementPlanDecisionTaskListStatus = TaskListStatus.NotRequired;
+                    EnterImprovementPlanObjectivesTaskListStatus = TaskListStatus.NotRequired;
+                    RequestImprovementGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
+                    ConfirmImprovementGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
+                }
+                else
+                {
+                    ChosePreferredSupportingOrganisationTaskListStatus =
+                        TaskStatusViewModel.ChoosePreferredSupportingOrganisationTaskListStatus(SupportProject);
+                    DueDiligenceOnPreferredSupportingOrganisationTaskListStatus =
+                        TaskStatusViewModel.DueDiligenceOnPreferredSupportingOrganisationTaskListStatus(SupportProject);
+                    SetRecordSupportingOrganisationAppointment =
+                        TaskStatusViewModel.SetRecordSupportingOrganisationAppointmentTaskListStatus(SupportProject);
+                    SupportingOrganisationContactDetailsTaskListStatus =
+                        TaskStatusViewModel.SupportingOrganisationContactDetailsTaskListStatus(SupportProject);
+
+                    // Phase 3
+                    RequestPlanningGrantOfferLetterTaskListStatus =
+                        TaskStatusViewModel.RequestPlanningGrantOfferLetterTaskListStatus(SupportProject);
+                    ConfirmPlanningGrantOfferLetterTaskListStatus =
+                        TaskStatusViewModel.ConfirmPlanningGrantOfferLetterTaskListStatus(SupportProject);
+                    ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus =
+                        TaskStatusViewModel.ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus(
+                            SupportProject);
+                    ReviewTheImprovementPlanTaskListStatus =
+                        TaskStatusViewModel.ReviewTheImprovementPlanTaskListStatus(SupportProject);
+                    SendAgreedImprovementPlanForApprovalTaskListStatus =
+                        TaskStatusViewModel.SendAgreedImprovementPlanForApprovalTaskListStatus(SupportProject);
+                    RecordImprovementPlanDecisionTaskListStatus =
+                        TaskStatusViewModel.RecordImprovementPlanDecisionTaskListStatus(SupportProject);
+                    EnterImprovementPlanObjectivesTaskListStatus =
+                        TaskStatusViewModel.EnterImprovementPlanObjectivesTaskListStatus(SupportProject);
+                    RequestImprovementGrantOfferLetterTaskListStatus =
+                        TaskStatusViewModel.RequestImprovementGrantOfferLetterTaskListStatus(SupportProject);
+                    ConfirmImprovementGrantOfferLetterTaskListStatus =
+                        TaskStatusViewModel.ConfirmImprovementGrantOfferLetterTaskListStatus(SupportProject);
+                }
             }
         }
 
-        
-        if (SupportProject is { InitialDiagnosisMatchingDecision: ReviewProgress or MatchWithASupportingOrganisation, CurrentDeliveryMilestone: not Milestone.TermlyReviews or Milestone.ImplementationAndTermlyReviews })
+
+        if (SupportProject is
+            {
+                InitialDiagnosisMatchingDecision: ReviewProgress or MatchWithASupportingOrganisation,
+                CurrentDeliveryMilestone: not Milestone.TermlyReviews or Milestone.ImplementationAndTermlyReviews
+            })
         {
             await SetFinalMilestone(id, SupportProject.InitialDiagnosisMatchingDecision, cancellationToken);
         }
-        
+
         return Page();
     }
 
@@ -268,7 +298,8 @@ public class IndexModel(
         ConfirmImprovementGrantOfferLetterTaskListStatus,
     ];
 
-    private async Task SetFinalMilestone(int id, string? initialDiagnosisMatchingDecision, CancellationToken cancellationToken)
+    private async Task SetFinalMilestone(int id, string? initialDiagnosisMatchingDecision,
+        CancellationToken cancellationToken)
     {
         if (!AllTasksComplete(ReviewProgressCommonTaskStatuses()))
         {

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/Index.cshtml.cs
@@ -206,7 +206,8 @@ public class IndexModel(
                     // Phase 3
                     RequestPlanningGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
                     ConfirmPlanningGrantOfferLetterTaskListStatus = TaskListStatus.NotRequired;
-                    ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus = TaskListStatus.NotRequired;
+                    ShareTheIndicativeFundingBandAndTheImprovementPlanTemplateTaskListStatus =
+                        TaskListStatus.NotRequired;
                     ReviewTheImprovementPlanTaskListStatus = TaskListStatus.NotRequired;
                     SendAgreedImprovementPlanForApprovalTaskListStatus = TaskListStatus.NotRequired;
                     RecordImprovementPlanDecisionTaskListStatus = TaskListStatus.NotRequired;

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml
@@ -20,7 +20,7 @@
         summaryItems = SummaryListHelper.For<IndexModel>(
             m => m.HasSchoolMatchedWithSupportingOrganisation!,
             m => m.RegionalDirectorDecisionDate!,
-            m => m.UnableToAssessNotes!        
+            m => m.UnableToAssessNotes!
         );
     }
     else
@@ -52,17 +52,18 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <span class="govuk-caption-l" data-cy="school-name">@Model.SupportProject.SchoolName</span>
+        <span class="govuk-caption-l" data-cy="school-name">@Model.SupportProject?.SchoolName</span>
         <h1 class="govuk-heading-l" data-cy="page-heading">
             Record initial diagnosis decision
         </h1>
 
         <p class="govuk-body">
             Using <a href="@Model.AssessmentToolOneLink" class="govuk-link"
-                                       target="_blank">Assessment Tool 1: Initial Diagnosis (opens in new tab)</a>,
+                     target="_blank">Assessment Tool 1: Initial Diagnosis (opens in new tab)</a>,
             confirm if this school will be matched with a supporting organisation or not. A regional director must have
             approved this decision.</p>
-        @if (Model.IsReadOnly)
+        @if (Model.IsReadOnly 
+             || Model.TaskIsComplete)
         {
             <govuk-summary-list model="Model" items="summaryItems"/>
         }
@@ -71,7 +72,6 @@
             <form method="post" novalidate>
                 <govuk-radiobuttons-input heading="Record decision"
                                           heading-style="govuk-fieldset__legend govuk-fieldset__legend--m"
-                                          hint="Enter the reasons for the decision if the school could not be assessed."
                                           name="@nameof(Model.HasSchoolMatchedWithSupportingOrganisation)"
                                           asp-for="@Model.HasSchoolMatchedWithSupportingOrganisation"
                                           radio-buttons="@Model.RadioButtonModels"

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
@@ -77,7 +77,7 @@ public class IndexModel(
             TaskListStatus = TaskStatusViewModel.RecordInitialDiagnosisDecisionTaskListStatus(SupportProject);
             ProjectStatus = SupportProject.ProjectStatus;
             
-            TaskIsComplete = SupportProject.InitialDiagnosisMatchingDecision is "Match with a supporting organisation" or "Unable to assess";
+            TaskIsComplete = SupportProject.InitialDiagnosisMatchingDecision is "Match with a supporting organisation" or "Review school's progress";
         }
 
         RadioButtonModels = RadioButtons;

--- a/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/TaskList/RecordInitialDiagnosisDecision/Index.cshtml.cs
@@ -36,6 +36,8 @@ public class IndexModel(
 
     public TaskListStatus? TaskListStatus { get; set; }
     public ProjectStatusValue? ProjectStatus { get; set; }
+
+    public bool TaskIsComplete { get; set; }
     
     public required IList<RadioButtonsLabelViewModel> RadioButtonModels { get; set; }
     public bool ShowError { get; set; }
@@ -74,7 +76,8 @@ public class IndexModel(
             
             TaskListStatus = TaskStatusViewModel.RecordInitialDiagnosisDecisionTaskListStatus(SupportProject);
             ProjectStatus = SupportProject.ProjectStatus;
-
+            
+            TaskIsComplete = SupportProject.InitialDiagnosisMatchingDecision is "Match with a supporting organisation" or "Unable to assess";
         }
 
         RadioButtonModels = RadioButtons;

--- a/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
+++ b/src/Dfe.ManageSchoolImprovement/ViewModels/TaskStatusViewModel.cs
@@ -183,7 +183,9 @@ public static class TaskStatusViewModel
     public static TaskListStatus RecordInitialDiagnosisDecisionTaskListStatus(SupportProjectViewModel supportProject)
     {
         if (supportProject.RegionalDirectorDecisionDate.HasValue
-            && !string.IsNullOrEmpty(supportProject.InitialDiagnosisMatchingDecision))
+            && !string.IsNullOrEmpty(supportProject.InitialDiagnosisMatchingDecision)
+            && (supportProject.InitialDiagnosisMatchingDecision.Equals("Match with a supporting organisation")
+            || supportProject.InitialDiagnosisMatchingDecision.Equals("Review school's progress")))
         {
             return TaskListStatus.Complete;
         }

--- a/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
+++ b/src/Tests/Dfe.ManageSchoolImprovement.Frontend.Tests/ViewModels/TaskStatusViewModelTests.cs
@@ -257,7 +257,7 @@ namespace Dfe.ManageSchoolImprovement.Frontend.Tests.ViewModels
                 { null, null, null, TaskListStatus.NotStarted },
                 { DateTime.Now, "Match with a supporting organisation", null, TaskListStatus.Complete },
                 { DateTime.Now, "Review school's progress", "Notes", TaskListStatus.Complete },
-                { DateTime.Now, "Unable to assess", "Notes", TaskListStatus.Complete },
+                { DateTime.Now, "Unable to assess", "Notes", TaskListStatus.InProgress },
                 { null, "Match with a supporting organisation", null, TaskListStatus.InProgress }
             };
 


### PR DESCRIPTION
- set task list status to not required when school is review progress
- remove hint text from initial diagnosis task
- make initial diagnosis task readonly when complete