### PR TITLE
Feature/288669 record progress tab before objectives

### DIFF
--- a/src/Dfe.ManageSchoolImprovement/Pages/ImprovementPlan/RecordProgress.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/ImprovementPlan/RecordProgress.cshtml
@@ -105,8 +105,7 @@
             <partial name="_ObjectiveSection"
                      model='("Personal development", Model.PersonalDevelopmentObjectives, Model.SupportProject.Id, Links.ImprovementPlan.RecordProgress.Page, Model.SupportProject.IsReadOnly, Model.CompletedReviews)'/>
         }
-        @if (!Model.NoProgressReviewsRecorded
-                 || (matchingDecisionHasChanged && Model.ObjectivesComplete))
+        @if (!Model.NoProgressReviewsRecorded)
         {
             @if (Model.CurrentReview != null)
             {

--- a/src/Dfe.ManageSchoolImprovement/Pages/ImprovementPlan/RecordProgress.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/ImprovementPlan/RecordProgress.cshtml
@@ -12,6 +12,8 @@
 
     var matchedSchool = Model.SupportProject?.InitialDiagnosisMatchingDecision == "Match with a supporting organisation";
     var reviewProgressSchool = Model.SupportProject?.InitialDiagnosisMatchingDecision == "Review school's progress";
+    var matchingDecisionHasChanged = Model.CurrentReview is { Type: "Review progress" }
+                           && matchedSchool;
 }
 
 @section BeforeMain {
@@ -42,7 +44,23 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Record progress</h2>
-        @if (matchedSchool && (Model.NoObjectivesRecorded || (!Model.ObjectivesComplete && Model.CurrentReview is null)) ||
+        @if (matchingDecisionHasChanged && !Model.ObjectivesComplete)
+        {
+            <h3 class="govuk-heading-m">Schools matched with a supporting organisation</h3>
+            <p>As you add the improvement plan objectives they will be listed on this page.</p>
+            <p>You will only be able to record a progress review when:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>an adviser has been allocated</li>
+                <li>all objectives have been added and marked as complete</li>
+            </ul>
+            
+            <a asp-page="@Links.ProgressReviews.Index.Page" asp-route-id="@Model.SupportProject?.Id" role="button"
+               draggable="false" class="govuk-button" data-module="govuk-button"
+               data-cy="view-progress-button">
+                View progress
+            </a>
+        }
+        else if (matchedSchool && (Model.NoObjectivesRecorded || (!Model.ObjectivesComplete && Model.CurrentReview is null)) ||
              !Model.IsAdviserAllocated
              || (!matchedSchool && !reviewProgressSchool))
         {
@@ -96,7 +114,8 @@
             <partial name="_ObjectiveSection"
                      model='("Personal development", Model.PersonalDevelopmentObjectives, Model.SupportProject.Id, Links.ImprovementPlan.RecordProgress.Page, Model.SupportProject.IsReadOnly, Model.CompletedReviews)'/>
         }
-        else if (!Model.NoProgressReviewsRecorded)
+        @if (!Model.NoProgressReviewsRecorded
+                 || (matchingDecisionHasChanged && Model.ObjectivesComplete))
         {
             @if (Model.CurrentReview != null)
             {
@@ -114,12 +133,13 @@
                 <partial name="_ReviewSummaryCard"
                          model="reviewSummaryCardModel"/>
             }
-            
-            @if (reviewProgressSchool && 
-                 Model.CurrentProgressReview != null && 
+
+            @if ((reviewProgressSchool || matchingDecisionHasChanged) &&
+                 Model.CurrentProgressReview != null &&
                  Model.CurrentProgressReview.ProgressStatus == ImprovementPlanReviewViewModel.ProgressStatusRecorded)
             {
-                <partial name="_ReviewProgressSummaryCard" model="(Model.CurrentProgressReview, Model.IsReadOnly, @Links.ImprovementPlan.RecordProgress.Page)"/>
+                <partial name="_ReviewProgressSummaryCard"
+                         model="(Model.CurrentProgressReview, Model.IsReadOnly, @Links.ImprovementPlan.RecordProgress.Page)"/>
             }
             else if (matchedSchool)
             {

--- a/src/Dfe.ManageSchoolImprovement/Pages/ProgressReviews/Index.cshtml
+++ b/src/Dfe.ManageSchoolImprovement/Pages/ProgressReviews/Index.cshtml
@@ -7,8 +7,12 @@
 
     bool progressReviewDeleted = (bool)(TempData["progressReviewDeleted"] ?? false);
     bool reviewDeleted = (bool)(TempData["reviewDeleted"] ?? false);
+    
+    var improvementPlan = Model.SupportProject?.ImprovementPlans?.FirstOrDefault();
 
     var matchedSchool = Model.SupportProject?.InitialDiagnosisMatchingDecision == "Match with a supporting organisation";
+    var matchingDecisionHasChanged = Model.CurrentProgressReview is { Type: "Review progress" }
+                                     && matchedSchool && (bool)!improvementPlan.ObjectivesSectionComplete;
 }
 
 @section BeforeMain
@@ -83,7 +87,7 @@
         else
         {
             <!-- No more reviews needed section -->
-            if (!Model.SupportProject!.IsReadOnly)
+            if (!Model.SupportProject!.IsReadOnly && !matchingDecisionHasChanged)
             {
                 <div class="govuk-inset-text govuk-!-margin-bottom-6">
                     @if (Model.CurrentProgressReview?.NextReviewDate is null)
@@ -91,7 +95,9 @@
                         <h2 class="govuk-heading-s govuk-!-margin-bottom-2">No more reviews needed</h2>
                         <p class="govuk-body govuk-!-margin-bottom-2">
                             <a asp-page="@Links.ProgressReviews.NextReview.Page" asp-route-id="@Model.SupportProject.Id"
-                               asp-route-reviewid="@Model.CurrentProgressReview?.ReadableId" class="govuk-link"
+                               asp-route-reviewid="@Model.CurrentProgressReview?.ReadableId"
+                               asp-route-reviewtype="@(matchingDecisionHasChanged ? "Matched" : Model.CurrentProgressReview?.Type)"
+                               class="govuk-link"
                                data-cy="add-next-review-date-link">Add next review date</a>
                         </p>
                     }
@@ -107,8 +113,6 @@
                                data-cy="next-review-date-change-link">Change next review date</a>
                         </p>
                     }
-
-
                 </div>
             }
 
@@ -128,7 +132,7 @@
             }
 
             <div class="govuk-button-group">
-                @if (!Model.SupportProject.IsReadOnly)
+                @if (!Model.SupportProject.IsReadOnly && !matchingDecisionHasChanged)
                 {
                     @if (matchedSchool)
                     {

--- a/src/Dfe.ManageSchoolImprovement/Pages/ProgressReviews/NextReview.cshtml.cs
+++ b/src/Dfe.ManageSchoolImprovement/Pages/ProgressReviews/NextReview.cshtml.cs
@@ -40,15 +40,14 @@ public class NextReviewModel(
     public bool ShowIsAnotherReviewNeededError => ModelState.ContainsKey(nameof(IsAnotherReviewNeeded)) && ModelState[nameof(IsAnotherReviewNeeded)]?.Errors.Count > 0;
     public bool ShowError => _errorService.HasErrors();
 
-    public async Task<IActionResult> OnGetAsync(int id, int reviewId, CancellationToken cancellationToken)
+    public async Task<IActionResult> OnGetAsync(int id, int reviewId, string reviewType, CancellationToken cancellationToken)
     {
         ReturnPage = Links.ProgressReviews.Index.Page;
         ReviewId = reviewId;
 
         await base.GetSupportProjectProgressReviews(id, cancellationToken);
 
-        if (SupportProject != null &&
-            SupportProject.InitialDiagnosisMatchingDecision == "Match with a supporting organisation")
+        if (SupportProject != null && reviewType == "Matched")
         {
             // Get the improvement plan and review from the support project
             ImprovementPlan = SupportProject?.ImprovementPlans?.First(x => x.ImprovementPlanReviews.Any(x => x.ReadableId == ReviewId));


### PR DESCRIPTION
When matching decision has changed but objective are not yet complete:

- amend content of record progress page (show partial text and previous review summary)
- remove add review button and add next review link from progress review page