### PR TITLE
Exclude false error for cypress test

### DIFF
--- a/SonarQube.Analysis.xml
+++ b/SonarQube.Analysis.xml
@@ -15,9 +15,9 @@
 	</Property>
 
 	<!-- rule-level issue exclusions -->
-	<Property Name="sonar.issue.ignore.multicriteria">cypressTestAssertionRule</Property>
-	<Property Name="sonar.issue.ignore.multicriteria.cypressTestAssertionRule.ruleKey">javascript:S2699</Property>
-	<Property Name="sonar.issue.ignore.multicriteria.cypressTestAssertionRule.resourceKey">**/src/Dfe.ManageSchoolImprovement.CypressTests/cypress/**/*.cy.ts</Property>
+	<Property Name="sonar.issue.ignore.multicriteria.cypressTestAssertionRule.resourceKey">
+       **/cypress/**/*.ts
+   </Property> 
 
 	<!-- coverage exclusions -->
 	<Property Name="sonar.coverage.exclusions">


### PR DESCRIPTION
Sonar Cloud issues : It looks like a false positive caused by a SonarCloud rule update rather than an issue with our cypress tests. As we are following POM structure, they are not explicit in the typescript test case (.cy.ts)
 Thus excluding the error.
 
 We have three options to resolve this:
- Ignore rule S2699 for Cypress tests ( recommended)
- Add an explicit assertion in every test (not practical for an existing suite).
 - Live with the warnings.